### PR TITLE
fix dummy sound device

### DIFF
--- a/rg3d-sound/src/device/dummy.rs
+++ b/rg3d-sound/src/device/dummy.rs
@@ -1,15 +1,16 @@
-#![allow(unused)]
-
 use crate::{
     device::{Device, FeedCallback, MixContext, NativeSample},
     error::SoundError,
 };
 use std::mem::size_of;
 
-pub struct DummySoundDevice {}
+pub struct DummySoundDevice;
 
-impl DummySoundDevice<F: FnMut(&mut [(f32, f32)]) + Send + 'static> {
-    pub fn new(_buffer_len_bytes: u32, _callback: F) -> Result<Self, SoundError> {
+impl DummySoundDevice {
+    pub fn new<F: FnMut(&mut [(f32, f32)]) + Send + 'static>(
+        _buffer_len_bytes: u32,
+        _callback: F,
+    ) -> Result<Self, SoundError> {
         Ok(Self)
     }
 }

--- a/rg3d-sound/src/device/mod.rs
+++ b/rg3d-sound/src/device/mod.rs
@@ -15,7 +15,7 @@ mod alsa;
 mod coreaudio;
 
 // The dummy target works on all platforms
-#[cfg(not(any(target_os = "windows", target_os = "linux", target_arch = "wasm32")))]
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos", target_arch = "wasm32")))]
 mod dummy;
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
1. Do not define `dummy` device on macOS
2. Let dummy device compile

I'm really not sure why it worked previously on macOS.