### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo check --verbose
     - name: Test
       run: cargo test --verbose
 
@@ -22,10 +22,23 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo check --verbose
     - name: Test
       run: cargo test --verbose
 
+  linux:
+    name: Linux CI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Dependencies
+      run: apt install libasound2-dev libudev-dev pkg-config
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo check --verbose
+    - name: Test
+      run: cargo test --verbose
+      
+  # MacOS 11 CI is currently in beta. Uncomment the below lines when it's out of beta.
   # macos11:
   #   name: MacOS Big Sur (M1) CI
   #   runs-on: macos-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Dependencies
-      run: apt install libasound2-dev libudev-dev pkg-config
+      run: sudo apt-get install libasound2-dev libudev-dev pkg-config
     - uses: actions/checkout@v2
     - name: Build
       run: cargo check --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI 
+on: [push, pull_request]
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  windows:
+    name: Windows CI
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Test
+      run: cargo test --verbose
+
+  macosx:
+    name: MacOSX CI
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Test
+      run: cargo test --verbose
+
+  # macos11:
+  #   name: MacOS Big Sur (M1) CI
+  #   runs-on: macos-11
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Build
+  #     run: cargo build --verbose
+  #   - name: Test
+  #     run: cargo test --verbose
+


### PR DESCRIPTION
This PR adds CI and closes #105. The CI currently checks and tests the codebase. 

Checking it via cargo check essentially makes sure the code will compile without actually compiling it. It still takes a bit to run (10 mins), but that's mainly due to the fact that it's not using incremental compilation and the library is quite large.

Please don't merge this until the tests on my branch have passed.

**TODO:**

- [ ] Add automated releases to the CI.