### PR TITLE
Add a mask_char to TextBox and FormattedText

### DIFF
--- a/rg3d-ui/src/formatted_text.rs
+++ b/rg3d-ui/src/formatted_text.rs
@@ -227,7 +227,6 @@ impl FormattedText {
             &self.text
         };
 
-
         // Split on lines.
         let mut total_height = 0.0;
         let mut current_line = TextLine::new();
@@ -471,7 +470,7 @@ impl FormattedTextBuilder {
             brush: Brush::Solid(Color::WHITE),
             constraint: Vector2::new(128.0, 128.0),
             wrap: WrapMode::NoWrap,
-            mask_char: None
+            mask_char: None,
         }
     }
 
@@ -510,13 +509,8 @@ impl FormattedTextBuilder {
         self
     }
 
-    pub fn with_mask_char(mut self, mask_char: char) -> Self {
-        self.mask_char = Some(mask_char);
-        self
-    }
-
-    pub fn with_no_mask_char(mut self) -> Self {
-        self.mask_char = None;
+    pub fn with_mask_char(mut self, mask_char: Option<char>) -> Self {
+        self.mask_char = mask_char;
         self
     }
 

--- a/rg3d-ui/src/text_box.rs
+++ b/rg3d-ui/src/text_box.rs
@@ -831,6 +831,7 @@ pub struct TextBoxBuilder<M: MessageData, C: Control<M, C>> {
     commit_mode: TextCommitMode,
     multiline: bool,
     editable: bool,
+    mask_char: Option<char>,
 }
 
 impl<M: MessageData, C: Control<M, C>> TextBoxBuilder<M, C> {
@@ -848,6 +849,7 @@ impl<M: MessageData, C: Control<M, C>> TextBoxBuilder<M, C> {
             commit_mode: TextCommitMode::LostFocusPlusEnter,
             multiline: false,
             editable: true,
+            mask_char: None,
         }
     }
 
@@ -906,6 +908,16 @@ impl<M: MessageData, C: Control<M, C>> TextBoxBuilder<M, C> {
         self
     }
 
+    pub fn with_mask_char(mut self, mask_char: char) -> Self {
+        self.mask_char = Some(mask_char);
+        self
+    }
+
+    pub fn with_no_mask_char(mut self) -> Self {
+        self.mask_char = None;
+        self
+    }
+
     pub fn build(mut self, ctx: &mut BuildContext<M, C>) -> Handle<UINode<M, C>> {
         if self.widget_builder.foreground.is_none() {
             self.widget_builder.foreground = Some(BRUSH_TEXT);
@@ -917,21 +929,23 @@ impl<M: MessageData, C: Control<M, C>> TextBoxBuilder<M, C> {
             self.widget_builder.cursor = Some(CursorIcon::Text);
         }
 
+        let mut formatted_text_builder = FormattedTextBuilder::new()
+                    .with_text(self.text)
+                    .with_font(self.font.unwrap_or_else(|| crate::DEFAULT_FONT.clone()))
+                    .with_horizontal_alignment(self.horizontal_alignment)
+                    .with_vertical_alignment(self.vertical_alignment)
+                    .with_wrap(self.wrap);
+        if let Some(mask_char) = self.mask_char {
+            formatted_text_builder = formatted_text_builder.with_mask_char(mask_char);
+        }
+
         let text_box = TextBox {
             widget: self.widget_builder.build(),
             caret_position: Position::default(),
             caret_visible: false,
             blink_timer: 0.0,
             blink_interval: 0.5,
-            formatted_text: RefCell::new(
-                FormattedTextBuilder::new()
-                    .with_text(self.text)
-                    .with_font(self.font.unwrap_or_else(|| crate::DEFAULT_FONT.clone()))
-                    .with_horizontal_alignment(self.horizontal_alignment)
-                    .with_vertical_alignment(self.vertical_alignment)
-                    .with_wrap(self.wrap)
-                    .build(),
-            ),
+            formatted_text: RefCell::new(formatted_text_builder.build()),
             selection_range: None,
             selecting: false,
             selection_brush: self.selection_brush,

--- a/rg3d-ui/src/text_box.rs
+++ b/rg3d-ui/src/text_box.rs
@@ -908,13 +908,8 @@ impl<M: MessageData, C: Control<M, C>> TextBoxBuilder<M, C> {
         self
     }
 
-    pub fn with_mask_char(mut self, mask_char: char) -> Self {
-        self.mask_char = Some(mask_char);
-        self
-    }
-
-    pub fn with_no_mask_char(mut self) -> Self {
-        self.mask_char = None;
+    pub fn with_mask_char(mut self, mask_char: Option<char>) -> Self {
+        self.mask_char = mask_char;
         self
     }
 
@@ -929,23 +924,22 @@ impl<M: MessageData, C: Control<M, C>> TextBoxBuilder<M, C> {
             self.widget_builder.cursor = Some(CursorIcon::Text);
         }
 
-        let mut formatted_text_builder = FormattedTextBuilder::new()
-                    .with_text(self.text)
-                    .with_font(self.font.unwrap_or_else(|| crate::DEFAULT_FONT.clone()))
-                    .with_horizontal_alignment(self.horizontal_alignment)
-                    .with_vertical_alignment(self.vertical_alignment)
-                    .with_wrap(self.wrap);
-        if let Some(mask_char) = self.mask_char {
-            formatted_text_builder = formatted_text_builder.with_mask_char(mask_char);
-        }
-
         let text_box = TextBox {
             widget: self.widget_builder.build(),
             caret_position: Position::default(),
             caret_visible: false,
             blink_timer: 0.0,
             blink_interval: 0.5,
-            formatted_text: RefCell::new(formatted_text_builder.build()),
+            formatted_text: RefCell::new(
+                FormattedTextBuilder::new()
+                    .with_text(self.text)
+                    .with_font(self.font.unwrap_or_else(|| crate::DEFAULT_FONT.clone()))
+                    .with_horizontal_alignment(self.horizontal_alignment)
+                    .with_vertical_alignment(self.vertical_alignment)
+                    .with_wrap(self.wrap)
+                    .with_mask_char(self.mask_char)
+                    .build(),
+            ),
             selection_range: None,
             selecting: false,
             selection_brush: self.selection_brush,


### PR DESCRIPTION
This adds a `with_mask_char` and `with_no_mask_char` to `TextBoxBuilder` and `FormattedText`.
Internally this changes the rendering of `FormattedText` to use a list of `mask_char` instead of `self.text` if the `mask_char` is set.
This does mean that multiline functionality does not work, as `code` is never `\n`, `\r` or a space, which is probably acceptable for password input fields.

![image](https://user-images.githubusercontent.com/2743142/126057679-bbaf7b0c-ffe2-4dae-88ae-6055cb70c716.png)

