### PR TITLE
Provide a way to alter control_flow passed in from the event loop

### DIFF
--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -10,6 +10,7 @@ use rg3d::{
     core::{algebra::Vector2, pool::Handle},
     engine::{framework::prelude::*, resource_manager::ResourceManager},
     event::{ElementState, VirtualKeyCode, WindowEvent},
+    event_loop::ControlFlow,
     gui::{
         message::{MessageDirection, TextMessage},
         text::TextBuilder,
@@ -128,7 +129,7 @@ impl GameState for Game {
         }
     }
 
-    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32) {
+    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32, _: &mut ControlFlow) {
         let mut offset = Vector2::default();
         if self.input_controller.move_forward {
             offset.y -= 10.0

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -19,6 +19,7 @@ use rg3d::{
     },
     engine::{framework::prelude::*, resource_manager::ResourceManager},
     event::{ElementState, VirtualKeyCode, WindowEvent},
+    event_loop::ControlFlow,
     gui::{
         grid::{Column, GridBuilder, Row},
         message::{MessageDirection, ProgressBarMessage, TextMessage, WidgetMessage},
@@ -257,7 +258,7 @@ impl GameState for Game {
         }
     }
 
-    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32) {
+    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32, _: &mut ControlFlow) {
         // Check each frame if our scene is created - here we just trying to lock context
         // without blocking, it is important for main thread to be functional while other
         // thread still loading data.

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -1,6 +1,7 @@
 use rg3d::{
     core::color::{Color, Hsv},
     engine::framework::prelude::*,
+    event_loop::ControlFlow,
 };
 
 struct Game {
@@ -16,7 +17,7 @@ impl GameState for Game {
     }
 
     // Implement a function that will update game logic and will be called at fixed rate of 60 Hz.
-    fn on_tick(&mut self, engine: &mut GameEngine, dt: f32) {
+    fn on_tick(&mut self, engine: &mut GameEngine, dt: f32, _: &mut ControlFlow) {
         // Increase hue at fixed rate of 24 degrees per second.
         self.hue += 24.0 * dt;
 

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -20,6 +20,7 @@ use rg3d::{
     },
     engine::{framework::prelude::*, resource_manager::ResourceManager},
     event::{ElementState, VirtualKeyCode, WindowEvent},
+    event_loop::ControlFlow,
     gui::{
         message::{MessageDirection, TextMessage},
         text::TextBuilder,
@@ -202,7 +203,7 @@ impl GameState for Game {
         }
     }
 
-    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32) {
+    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32, _: &mut ControlFlow) {
         // Use stored scene handle to borrow a mutable reference of scene in
         // engine.
         let scene = &mut engine.scenes[self.scene];

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,6 +19,7 @@ use rg3d::{
     },
     engine::{framework::prelude::*, resource_manager::ResourceManager},
     event::{ElementState, VirtualKeyCode, WindowEvent},
+    event_loop::ControlFlow,
     gui::{
         message::{MessageDirection, TextMessage},
         text::TextBuilder,
@@ -174,7 +175,7 @@ impl GameState for Game {
         }
     }
 
-    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32) {
+    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32, _: &mut ControlFlow) {
         let scene = &mut engine.scenes[self.scene];
 
         // Our animation must be applied to scene explicitly, otherwise

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -14,6 +14,7 @@ use rg3d::{
     },
     engine::{framework::prelude::*, resource_manager::ResourceManager},
     event::{ElementState, VirtualKeyCode, WindowEvent},
+    event_loop::ControlFlow,
     gui::{
         message::{MessageDirection, TextMessage},
         text::TextBuilder,
@@ -162,7 +163,7 @@ impl GameState for Game {
         }
     }
 
-    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32) {
+    fn on_tick(&mut self, engine: &mut GameEngine, _dt: f32, _: &mut ControlFlow) {
         // Use stored scene handle to borrow a mutable reference of scene in
         // engine.
         let scene = &mut engine.scenes[self.scene];

--- a/src/engine/framework.rs
+++ b/src/engine/framework.rs
@@ -44,8 +44,8 @@ pub trait GameState: 'static {
         Self: Sized;
 
     /// Defines a function that will contain game logic. It has stabilized update rate of
-    /// 60 Hz.
-    fn on_tick(&mut self, _engine: &mut GameEngine, _dt: f32) {}
+    /// 60 Hz. Callee can alter control flow of the game by modifying _control_flow parameter.
+    fn on_tick(&mut self, _engine: &mut GameEngine, _dt: f32, _control_flow: &mut ControlFlow) {}
 
     /// Defines a function that will be called when there is any message from user interface.
     fn on_ui_message(&mut self, _engine: &mut GameEngine, _message: UiMessage) {}
@@ -116,7 +116,7 @@ impl<State: GameState> Framework<State> {
                         dt -= fixed_timestep;
                         elapsed_time += fixed_timestep;
 
-                        state.on_tick(&mut engine, fixed_timestep);
+                        state.on_tick(&mut engine, fixed_timestep, control_flow);
 
                         engine.update(fixed_timestep);
                     }


### PR DESCRIPTION
The GameState trait doesn't provide a way to exit the game programmatically. This provides a way for the on_tick() method to do that.