### PR TITLE
Add error implementations using thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tbc = "0.3.0"
 bitflags = "1.2.1"
 glow = "0.10"
 walkdir = "2"
+thiserror = "1.0.26"
 
 [dev-dependencies]
 imageproc = "0.22.0"

--- a/rg3d-sound/src/error.rs
+++ b/rg3d-sound/src/error.rs
@@ -96,3 +96,5 @@ impl Display for SoundError {
         }
     }
 }
+
+impl std::error::Error for SoundError {}

--- a/src/engine/error.rs
+++ b/src/engine/error.rs
@@ -3,13 +3,16 @@
 use crate::{renderer::framework::error::FrameworkError, sound::error::SoundError};
 
 /// See module docs.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EngineError {
     /// Sound system error.
+    #[error(transparent)]
     Sound(SoundError),
     /// Rendering system error.
+    #[error(transparent)]
     Renderer(FrameworkError),
     /// Internal error.
+    #[error("Custom error: {0}")]
     Custom(String),
 }
 

--- a/src/renderer/framework/error.rs
+++ b/src/renderer/framework/error.rs
@@ -4,8 +4,9 @@
 use std::ffi::NulError;
 
 /// Set of possible renderer errors.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum FrameworkError {
+    #[error("Compilation of \"{}\" shader has failed: {}", shader_name, error_message)]
     /// Compilation of a shader has failed.
     ShaderCompilationFailed {
         /// Name of shader.
@@ -14,6 +15,7 @@ pub enum FrameworkError {
         error_message: String,
     },
     /// Means that shader link stage failed, exact reason is inside `error_message`
+    #[error("Linking shader \"{}\" failed: {}", shader_name, error_message)]
     ShaderLinkingFailed {
         /// Name of shader.
         shader_name: String,
@@ -21,10 +23,13 @@ pub enum FrameworkError {
         error_message: String,
     },
     /// Shader source contains invalid characters.
+    #[error("Shader source contains invalid characters")]
     FaultyShaderSource,
     /// There is no such shader uniform (could be optimized out).
+    #[error("There is no such shader uniform: {0}")]
     UnableToFindShaderUniform(String),
     /// Texture has invalid data - insufficient size.
+    #[error("Texture has invalid data (insufficent size): expected {}, actual: {}", expected_data_size, actual_data_size)]
     InvalidTextureData {
         /// Expected data size in bytes.
         expected_data_size: usize,
@@ -32,9 +37,17 @@ pub enum FrameworkError {
         actual_data_size: usize,
     },
     /// None variant was passed as texture data, but engine does not support it.
+    #[error("None variant was passed as texture data, but engine does not support it.")]
     EmptyTextureData,
     /// Means that you tried to draw element range from GeometryBuffer that
     /// does not have enough elements.
+    #[error(
+        "Tried to draw element from GeometryBuffer that does not have enough elements:
+        start: {},
+        end: {},
+        total: {}
+        ", start, end, total
+    )]
     InvalidElementRange {
         /// First index.
         start: usize,
@@ -48,12 +61,16 @@ pub enum FrameworkError {
     ///   pos: float2,
     ///   normal: float3
     /// But you described second attribute as Float4, then you'll get this error.
+    #[error("An attribute descriptor tried to define an attribute that does not exist in vertex or doesn't match size.")]
     InvalidAttributeDescriptor,
     /// Framebuffer is invalid.
+    #[error("Framebuffer is invalid")]
     InvalidFrameBuffer,
     /// OpenGL failed to construct framebuffer.
+    #[error("OpenGL failed to construct framebuffer.")]
     FailedToConstructFBO,
     /// Custom error. Usually used for internal errors.
+    #[error("Custom error: {0}")]
     Custom(String),
 }
 


### PR DESCRIPTION
Adds an error implementation using `thiserror` to `FrameworkError`,
`EngineError`, and `SoundError`.
This adds `thiserror` as a dependency.

I tried to base the error messages off of the existing doc comments, so hopefully they should all be correct.

My reasoning behind doing this was so I could avoid using unwrap in various places while using `Framework` and instead use the `?` operator.