### PR TITLE
Update Cargo.tomls and add icon for docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,13 @@ edition = "2018"
 license = "MIT"
 description = "3D Game engine"
 keywords = ["sound", "game", "engine", "3d", "gui"]
+categories = ["game-engines", "graphics", "gui", "rendering", "wasm"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE", "/README.md"]
+homepage = "https://rg3d.rs"
+documentation = "https://docs.rs/rg3d"
 repository = "https://github.com/mrDIMAS/rg3d"
 readme = "README.md"
+resolver = "2"
 
 [workspace]
 members = ["rg3d-core-derive", "rg3d-core", "rg3d-sound", "rg3d-ui", "rg3d-resource", "examples/wasm"]
@@ -27,7 +31,7 @@ rg3d-resource = { path = "rg3d-resource", version = "0.2.0" }
 image = { version = "0.23", default-features = false, features = ["gif", "jpeg", "png", "tga", "tiff", "bmp"] }
 lexical = "5.2.2"
 inflate = "0.4.5"
-serde = { version = "^1.0.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }
 lazy_static = "1.4.0"
 ddsfile = "0.4.0"
 rapier3d = { version = "0.11" }
@@ -52,5 +56,3 @@ glutin = {version = "0.27.0", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = { version = "0.25.0", features = ["web-sys", "serde"] }
-
-

--- a/rg3d-core-derive/Cargo.toml
+++ b/rg3d-core-derive/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.13.0"
 authors = ["toyboot4e <toyboot4e@gmail.com>, Dmitry Stepanov <d1maxa@yandex.ru>"]
 edition = "2018"
 license = "MIT"
-description = "Proc-macro for Visit trait"
+description = "Proc-macro for the Visit trait"
 repository = "https://github.com/mrDIMAS/rg3d"
 include = ["/src/**/*", "/Cargo.toml", "/README.md"]
 readme = "README.md"
+resolver = "2"
 
 [lib]
 proc-macro = true

--- a/rg3d-core-derive/README.md
+++ b/rg3d-core-derive/README.md
@@ -1,4 +1,3 @@
 # rg3d-core-derive
 
-Provides `#[derive(Visitor)]` macro, which implements `rg3d::core::visitor::Visit`.
-
+Provides the `#[derive(Visitor)]` macro, which implements `rg3d::core::visitor::Visit`.

--- a/rg3d-core/Cargo.toml
+++ b/rg3d-core/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.18.0"
 authors = ["Dmitry Stepanov <d1maxa@yandex.ru>"]
 edition = "2018"
 license = "MIT"
-description = "Shared core for rg3d engine and its external crates."
-repository = "https://github.com/mrDIMAS/rg3d"
+description = "Shared core for the rg3d engine and its external crates."
+keywords = ["game", "engine", "3d"]
+categories = ["game-development", "graphics", "gui", "rendering", "wasm"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE", "/README.md"]
+homepage = "https://rg3d.rs"
+documentation = "https://docs.rs/rg3d-core"
+repository = "https://github.com/mrDIMAS/rg3d"
 readme = "README.md"
+resolver = "2"
 
 [dependencies]
 rg3d-core-derive = { path = "../rg3d-core-derive", version = "0.13.0" }

--- a/rg3d-resource/Cargo.toml
+++ b/rg3d-resource/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.2.0"
 authors = ["Dmitry Stepanov <d1maxa@yandex.ru>"]
 edition = "2018"
 license = "MIT"
-description = "Asset management crate for rg3d engine"
+description = "Asset management crate for the rg3d engine"
 keywords = ["asset", "resource"]
-repository = "https://github.com/mrDIMAS/rg3d"
+categories = ["game-development"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE"]
+homepage = "https://rg3d.rs"
 documentation = "https://docs.rs/rg3d-resource"
+repository = "https://github.com/mrDIMAS/rg3d"
+resolver = "2"
 
 [dependencies]
 rg3d-core = { path = "../rg3d-core", version = "0.18.0" }

--- a/rg3d-sound/Cargo.toml
+++ b/rg3d-sound/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2018"
 license = "MIT"
 description = "Sound library for games."
 keywords = ["sound", "game", "hrtf", "binaural", "reverb"]
-repository = "https://github.com/mrDIMAS/rg3d"
+categories = ["game-development", "multimedia::audio"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE", "/README.md", "/examples/*"]
+homepage = "https://rg3d.rs"
 documentation = "https://docs.rs/rg3d-sound"
+repository = "https://github.com/mrDIMAS/rg3d"
 readme = "README.md"
+resolver = "2"
 
 [dependencies]
 rg3d-core = { path = "../rg3d-core", version = "0.18.0" }

--- a/rg3d-ui/Cargo.toml
+++ b/rg3d-ui/Cargo.toml
@@ -6,9 +6,13 @@ edition = "2018"
 license = "MIT"
 description = "Extendable UI library"
 keywords = ["ui", "game", "gui"]
-repository = "https://github.com/mrDIMAS/rg3d"
+categories = ["game-development", "gui"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE", "/README.md"]
+homepage = "https://rg3d.rs"
+documentation = "https://docs.rs/rg3d-ui"
+repository = "https://github.com/mrDIMAS/rg3d"
 readme = "README.md"
+resolver = "2"
 
 [dependencies]
 rg3d-core = { path = "../rg3d-core", version = "0.18.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
 //! 3D and 2D Game Engine.
 
+#![doc(
+    html_logo_url = "https://rg3d.rs/assets/logos/logo2.png",
+    html_favicon_url = "https://rg3d.rs/assets/logos/logo2.png"
+)]
+
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::from_over_into)]


### PR DESCRIPTION
Unified the order of fields, added some fields (mainly categories). The new resolver ( https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2 ) shouldn't influence much, in theory it could improve compile times in some situations. I think it's mostly important for binaries but can't hurt to spread awareness of it. Also added icon that will show up on docs.rs, at least for the main crate (bevy does it this way too).