### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@
 
 [![License (MIT)](https://img.shields.io/crates/l/rg3d)](https://github.com/mrDIMAS/rg3d/blob/master/LICENSE.md)
 [![CI Status](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml/badge.svg)](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml)
+[![Dependency status](https://deps.rs/repo/github/rg3dengine/rg3d/status.svg)](https://deps.rs/repo/github/rg3dengine/rg3d)
 [![Crates.io](https://img.shields.io/crates/v/rg3d)](https://crates.io/crates/rg3d)
 [![docs.rs](https://img.shields.io/badge/docs-website-blue)](https://docs.rs/rg3d/)
 [![Discord](https://img.shields.io/discord/756573453561102427)](https://discord.gg/xENF5Uh)
 [![Lines of code](https://tokei.rs/b1/github/mrDIMAS/rg3d)](https://github.com/mrDIMAS/rg3d)
- 
+
 A feature-rich, production-ready, general purpose 2D/3D game engine written in Rust with a scene editor.
 
 ## Support
 
 If you want to support the development of the project, click the link below. I'm working on the project full time and
-use my savings to drive development forward, I'm looking for any financial support. 
+use my savings to drive development forward, I'm looking for any financial support.
 
 [![Become a patron!](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/mrdimas)
 
@@ -157,7 +158,7 @@ use my savings to drive development forward, I'm looking for any financial suppo
 - File selector widget.
 - Docking manager widget.
 - NumericUpDown widget.
-- Vector3<f32> editor widget.
+- `Vector3<f32>` editor widget.
 - Menu widget.
 - Menu item widget.
 - Message box widget.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-[![RG3D](pics/logo.png)](https://rg3d.rs/)
+<div align="center">
+  <a href="https://rg3d.rs/">
+    <img src="pics/logo.png" alt="RG3D" />
+  </a>
 
-# Rust Game engine 3D (and 2D)
+  <h1>Rust Game engine 3D (and 2D)</h1>
+</div>
 
 [![License (MIT)](https://img.shields.io/crates/l/rg3d)](https://github.com/mrDIMAS/rg3d/blob/master/LICENSE.md)
 [![CI Status](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml/badge.svg)](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml)


### PR DESCRIPTION
Fixed one bullet point (previously didn't display the `<f32>` part because it was treated as an html tag - caught by markdownlint)

Moved the image and main heading to the center - i think it looks better but let me know what you think. Crates.io should also handle it (it handles headings for my crates but i haven't tried a centered image yet).

Also added deps.rs - i think this website is awesome and more crates should use it since it lets you know at a glance if anything needs updating even before it shows up in cargo audit.