### PR TITLE
Deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ rg3d-sound = { path = "rg3d-sound", version = "0.25.0" }
 rg3d-ui = { path = "rg3d-ui", version = "0.14.0" }
 rg3d-resource = { path = "rg3d-resource", version = "0.2.0" }
 image = { version = "0.23.12", default-features = false, features = ["gif", "jpeg", "png", "tga", "tiff", "bmp"] }
-lexical = "5.2.2"
+lexical = { version = "6.0.0", default-features = false, features = ["std", "parse-integers", "parse-floats"] }
+lexical-parse-float = "0.8.0"
 inflate = "0.4.5"
 serde = { version = "^1.0.0", features = ["derive"] }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rg3d-core = { path = "rg3d-core", version = "0.18.0", features = ["serde"] }
 rg3d-sound = { path = "rg3d-sound", version = "0.25.0" }
 rg3d-ui = { path = "rg3d-ui", version = "0.14.0" }
 rg3d-resource = { path = "rg3d-resource", version = "0.2.0" }
-image = { version = "0.23", default-features = false, features = ["gif", "jpeg", "png", "tga", "tiff", "bmp"] }
+image = { version = "0.23.12", default-features = false, features = ["gif", "jpeg", "png", "tga", "tiff", "bmp"] }
 lexical = "5.2.2"
 inflate = "0.4.5"
 serde = { version = "^1.0.0", features = ["derive"] }

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -4,8 +4,6 @@
 //!
 //! This example shows simple 2D scene with light sources.
 
-extern crate rg3d;
-
 use rg3d::{
     core::{algebra::Vector2, pool::Handle},
     engine::{framework::prelude::*, resource_manager::ResourceManager},

--- a/examples/3rd_person.rs
+++ b/examples/3rd_person.rs
@@ -22,8 +22,6 @@
 //!    for combat, lower - for locomotion.
 //!  - Tons of them, this is simple example after all.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::{create_ui, fix_shadows_distance, Game, GameScene};

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -5,8 +5,6 @@
 //! This example shows how to load scene in separate thread and how create standard
 //! loading screen which will show progress.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use rg3d::{

--- a/examples/compressed_textures.rs
+++ b/examples/compressed_textures.rs
@@ -3,8 +3,6 @@
 //! Just shows two textures with compression. Engine compresses textures automatically,
 //! based on compression options.
 
-extern crate rg3d;
-
 use rg3d::{
     core::{algebra::Vector2, color::Color},
     engine::{framework::prelude::*, resource_manager::TextureImportOptions},

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -5,8 +5,6 @@
 //! This example shows how to create simple scene with lots of animated models with low performance
 //! impact.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -5,8 +5,6 @@
 //! This example shows how to load simple scene made in [rusty-editor](https://github.com/mrDIMAS/rusty-editor)
 //! and generate lightmap for it. Lightmaps are still in active development and not meant to be used.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -4,8 +4,6 @@
 //!
 //! This example shows how create a simple object with few detail levels.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/material.rs
+++ b/examples/material.rs
@@ -4,8 +4,6 @@
 //!
 //! This example shows how to create simple scene with a mesh with custom shader.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -4,8 +4,6 @@
 //!
 //! This example shows how to create simple scene with animated model.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/save_load.rs
+++ b/examples/save_load.rs
@@ -15,8 +15,6 @@
 //! You should carefully read documentation of rg3d::core::Visitor to understand basic ideas
 //! of how it works, otherwise Visit trait implementation might be confusing.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::{create_ui, fix_shadows_distance, Game, GameScene, LocomotionMachine, Player};

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -6,8 +6,6 @@
 //!
 //! It is almost the same as Example 01, even easier.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,8 +4,6 @@
 //!
 //! This example shows how to create simple scene with animated model.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -6,8 +6,6 @@
 //!
 //!
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::{create_ui, fix_shadows_distance, Game, GameScene};

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -1,7 +1,5 @@
 //! Example - Terrain.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -6,8 +6,6 @@
 //! based on framework example because UI will be used to operate on
 //! model.
 
-extern crate rg3d;
-
 pub mod shared;
 
 use crate::shared::create_camera;

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -4,8 +4,6 @@
 //!
 //! Warning - Work in progress!
 
-extern crate rg3d;
-
 use rg3d::engine::resource_manager::MaterialSearchOptions;
 use rg3d::material::shader::SamplerFallback;
 use rg3d::material::{Material, PropertyValue};

--- a/rg3d-sound/src/lib.rs
+++ b/rg3d-sound/src/lib.rs
@@ -66,14 +66,6 @@
 #[cfg(target_os = "windows")]
 extern crate winapi;
 
-#[cfg(target_os = "linux")]
-extern crate alsa_sys;
-
-// Generic crates.
-extern crate hound;
-extern crate lewton;
-extern crate rg3d_core;
-
 pub mod buffer;
 pub mod context;
 

--- a/rg3d-ui/src/lib.rs
+++ b/rg3d-ui/src/lib.rs
@@ -10,11 +10,6 @@
 
 #[macro_use]
 extern crate lazy_static;
-extern crate copypasta;
-extern crate fontdue;
-
-#[cfg(not(target_arch = "wasm32"))]
-extern crate sysinfo;
 
 pub use rg3d_core as core;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,24 +4,6 @@
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::from_over_into)]
 
-extern crate bitflags;
-extern crate ddsfile;
-extern crate glow;
-#[cfg(not(target_arch = "wasm32"))]
-extern crate glutin;
-extern crate image;
-extern crate inflate;
-extern crate lexical;
-extern crate rayon;
-extern crate ron;
-extern crate serde;
-
-#[cfg(target_arch = "wasm32")]
-extern crate winit;
-
-#[cfg(test)]
-extern crate imageproc;
-
 pub mod animation;
 pub mod engine;
 pub mod material;

--- a/src/resource/fbx/document/attribute.rs
+++ b/src/resource/fbx/document/attribute.rs
@@ -1,5 +1,7 @@
 use std::fmt::Formatter;
 
+use lexical_parse_float::Options;
+
 pub enum FbxAttribute {
     Double(f64),
     Float(f32),
@@ -58,10 +60,14 @@ impl FbxAttribute {
             FbxAttribute::Integer(val) => Ok(f64::from(*val)),
             FbxAttribute::Long(val) => Ok(*val as f64),
             FbxAttribute::Bool(val) => Ok((*val as i64) as f64),
-            FbxAttribute::String(val) => match lexical::parse_lossy::<f64, _>(val.as_str()) {
-                Ok(i) => Ok(i),
-                Err(_) => Err(format!("Unable to convert string {} to f64", val)),
-            },
+            FbxAttribute::String(val) => {
+                const FORMAT: u128 = lexical::format::STANDARD;
+                let options = Options::builder().lossy(true).build().unwrap();
+                match lexical::parse_with_options::<f64, _, FORMAT>(val.as_str(), &options) {
+                    Ok(i) => Ok(i),
+                    Err(_) => Err(format!("Unable to convert string {} to f64", val)),
+                }
+            }
         }
     }
 
@@ -72,10 +78,14 @@ impl FbxAttribute {
             FbxAttribute::Integer(val) => Ok(*val as f32),
             FbxAttribute::Long(val) => Ok(*val as f32),
             FbxAttribute::Bool(val) => Ok((*val as i32) as f32),
-            FbxAttribute::String(val) => match lexical::parse_lossy::<f32, _>(val.as_str()) {
-                Ok(i) => Ok(i),
-                Err(_) => Err(format!("Unable to convert string {} to f32", val)),
-            },
+            FbxAttribute::String(val) => {
+                const FORMAT: u128 = lexical::format::STANDARD;
+                let options = Options::builder().lossy(true).build().unwrap();
+                match lexical::parse_with_options::<f32, _, FORMAT>(val.as_str(), &options) {
+                    Ok(i) => Ok(i),
+                    Err(_) => Err(format!("Unable to convert string {} to f32", val)),
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Updates the 2 deps that are yellow on deps.rs.

Also removed `extern crate` - it should be no longer necessary in 2018 edition or is there any reason why you used it?