### PR TITLE
Fix docs warnings

### DIFF
--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -355,7 +355,7 @@ impl Base {
     /// using visibility of all parent nodes until root one, so if some parent node upper on tree is invisible then
     /// all its children will be invisible. It defines if object will be rendered. It is *not* the same as real
     /// visibility from point of view of a camera. To check if object is visible from some camera, use
-    /// [VisibilityCache](super::VisibilityCache). However this still can't tell you if object is behind obstacle or not.
+    /// [VisibilityCache](super::visibility::VisibilityCache). However this still can't tell you if object is behind obstacle or not.
     pub fn global_visibility(&self) -> bool {
         self.global_visibility.get()
     }

--- a/src/scene/camera.rs
+++ b/src/scene/camera.rs
@@ -407,7 +407,7 @@ pub enum ColorGradingLutCreationError {
 /// you've probably noticed either "warmness" or "coldness" in colors in various scenes in
 /// games - this is achieved by color grading.
 ///
-/// See more info here - https://docs.unrealengine.com/4.26/en-US/RenderingAndGraphics/PostProcessEffects/UsingLUTs/
+/// See [more info in Unreal engine docs](https://docs.unrealengine.com/4.26/en-US/RenderingAndGraphics/PostProcessEffects/UsingLUTs/)
 #[derive(Visit, Clone, Default, Debug)]
 pub struct ColorGradingLut {
     #[visit(skip)]

--- a/src/scene/node.rs
+++ b/src/scene/node.rs
@@ -90,7 +90,7 @@ impl Visit for Node {
 ///
 /// Please keep in mind that "visibility" here means some sort of a "switch" that tells the renderer whether to draw
 /// the node or not. To fetch actual visibility of the node from a camera's perspective, use
-/// [visibility cache](super::camera::VisibilityCache) of the camera.
+/// [visibility cache](super::visibility::VisibilityCache) of the camera.
 ///
 /// # Level of details
 ///

--- a/src/utils/behavior/mod.rs
+++ b/src/utils/behavior/mod.rs
@@ -10,7 +10,7 @@
 //! custom method `tick` that can contain any logic you want.
 //!
 //! For more info see:
-//! - [Wikipedia article](https://en.wikipedia.org/wiki/Behavior_tree_(artificial_intelligence,_robotics_and_control)
+//! - [Wikipedia article](https://en.wikipedia.org/wiki/Behavior_tree_(artificial_intelligence,_robotics_and_control))
 //! - [Gamasutra](https://www.gamasutra.com/blogs/ChrisSimpson/20140717/221339/Behavior_trees_for_AI_How_they_work.php)
 
 use crate::{


### PR DESCRIPTION
This should make docs CI pass even with `RUSTDOCFLAGS: --deny warnings`. There are still unused field warns in UI but those don't get converted to errors.