### PR TITLE
Fix docs CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,16 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: rustc --version && cargo --version
       - name: Build Docs
-        run: |
-          rustup run stable cargo doc
+        run: cargo doc --all-features
+        env:
+          RUSTDOCFLAGS: --deny warnings
 
 
   # MacOS 11 CI is currently in beta. Uncomment the below lines when it's out of beta.


### PR DESCRIPTION
This currently fails (at least we know it works properly), the issues are fixed on another MR.

Also, why use windows-2019? Any particular reason? I think i heard that docs on linux can be a bit faster because windows is slower with lots of files but idk if it applies here or if it matters.