### PR TITLE
Cargo audit CI + badge

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,28 @@
+name: audit
+
+# This is a separate file so it can have a separate badge in readme
+# and therefore spread awareness of cargo audit a tiny bit.
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # Runs at 15:00 UTC on Fri
+    - cron: "0 15 * * 5"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-audit
+          version: latest
+      - run: cargo audit --version
+      - run: cargo audit --deny warnings

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /cloc
 *.lock
 .*
+!.github
 /*.log
 /*.png
 /examples/data/lightmaps

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![License (MIT)](https://img.shields.io/crates/l/rg3d)](https://github.com/mrDIMAS/rg3d/blob/master/LICENSE.md)
 [![CI Status](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml/badge.svg)](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml)
+[![Audit](https://github.com/martin-t/cvars/workflows/audit.yml/badge.svg)](https://github.com/rg3dengine/rg3d/actions/workflows/audit.yml)
 [![Crates.io](https://img.shields.io/crates/v/rg3d)](https://crates.io/crates/rg3d)
 [![docs.rs](https://img.shields.io/badge/docs-website-blue)](https://docs.rs/rg3d/)
 [![Discord](https://img.shields.io/discord/756573453561102427)](https://discord.gg/xENF5Uh)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License (MIT)](https://img.shields.io/crates/l/rg3d)](https://github.com/mrDIMAS/rg3d/blob/master/LICENSE.md)
 [![CI Status](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml/badge.svg)](https://github.com/rg3dengine/rg3d/actions/workflows/ci.yml)
-[![Audit](https://github.com/martin-t/cvars/workflows/audit.yml/badge.svg)](https://github.com/rg3dengine/rg3d/actions/workflows/audit.yml)
+[![audit](https://github.com/rg3dengine/rg3d/workflows/audit.yml/badge.svg)](https://github.com/rg3dengine/rg3d/actions/workflows/audit.yml)
 [![Crates.io](https://img.shields.io/crates/v/rg3d)](https://crates.io/crates/rg3d)
 [![docs.rs](https://img.shields.io/badge/docs-website-blue)](https://docs.rs/rg3d/)
 [![Discord](https://img.shields.io/discord/756573453561102427)](https://discord.gg/xENF5Uh)


### PR DESCRIPTION
Detect vulnerable deps

This should currently fail because there are multiple issues.

In general, some issues are impossible to fix immediately and ok to ignore short term - like warnings that something is unmaintained - there's a flag for ignoring specific advisories - that's better than removing --deny warnings because it makes you notice new warns.

Cargo audit and deps.rs works best when your deps use it too :/

Oh and it runs on a timed schedule so even if you don't touch rg3d for over a week and a new vuln pops up, you'll get notified.

This is in a separate file so it doesn't fail *all* CI and also because we can add another separate badge for this and spread awareness. Which would be awesome.

If i find time tomorrow, i want to try going through some deps and improving their CIs + adding deps.rs and updating their deps but no promises. My "tomorrow" tends to mean "next week" or worse ;)