### PR TITLE
Initial support of `#[derive(Inspect)]`

### DIFF
--- a/rg3d-core-derive/Cargo.toml
+++ b/rg3d-core-derive/Cargo.toml
@@ -22,4 +22,5 @@ darling = "0.13.0"
 
 [dev-dependencies]
 rg3d-core = { path = "../rg3d-core" }
+rg3d = { path = "../" }
 futures = "0.3.16"

--- a/rg3d-core-derive/README.md
+++ b/rg3d-core-derive/README.md
@@ -1,3 +1,3 @@
 # rg3d-core-derive
 
-Provides the `#[derive(Visitor)]` macro, which implements `rg3d::core::visitor::Visit`.
+Provides the `#[derive(Visit)]` macro, which implements `rg3d::core::visitor::Visit`.

--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -27,7 +27,6 @@ fn impl_inspect_struct(
     );
 
     let impl_body = {
-        // `field.visit(..);` parts
         let props = utils::create_field_properties(
             quote! {  self. },
             field_args.fields.iter(),

--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -1,0 +1,54 @@
+//! Implements `Inspect` trait
+
+mod args;
+mod utils;
+
+use darling::{ast, FromDeriveInput};
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::*;
+
+pub fn impl_inspect(ast: DeriveInput) -> TokenStream2 {
+    let ty_args = args::TypeArgs::from_derive_input(&ast).unwrap();
+    match &ty_args.data {
+        ast::Data::Struct(ref field_args) => self::impl_inspect_struct(&ty_args, field_args),
+        ast::Data::Enum(ref variant_args) => self::impl_inspect_enum(&ty_args, variant_args),
+    }
+}
+
+fn impl_inspect_struct(
+    ty_args: &args::TypeArgs,
+    field_args: &ast::Fields<args::FieldArgs>,
+) -> TokenStream2 {
+    assert_eq!(
+        field_args.style,
+        ast::Style::Struct,
+        "#[derive(Inspect) considers only named fields for now"
+    );
+
+    let impl_body = {
+        // `field.visit(..);` parts
+        let props = utils::create_field_properties(
+            quote! {  self. },
+            field_args.fields.iter(),
+            field_args.style,
+        );
+
+        quote! {
+            vec![
+                #(
+                    #props,
+                )*
+            ]
+        }
+    };
+
+    utils::create_impl(ty_args, field_args.iter().cloned(), impl_body)
+}
+
+fn impl_inspect_enum(
+    _ty_args: &args::TypeArgs,
+    _variant_args: &[args::VariantArgs],
+) -> TokenStream2 {
+    todo!("#[derive(Inspect)] is only for structure types for now")
+}

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -6,7 +6,7 @@ use darling::*;
 use syn::*;
 
 #[derive(FromDeriveInput)]
-#[darling(attributes(visit), supports(struct_any, enum_any))]
+#[darling(attributes(inspect), supports(struct_any, enum_any))]
 pub struct TypeArgs {
     pub ident: Ident,
     pub generics: Generics,
@@ -15,10 +15,25 @@ pub struct TypeArgs {
 
 /// Parsed from struct's or enum variant's field
 #[derive(FromField, Clone)]
-#[darling(attributes(visit))]
+#[darling(attributes(inspect))]
 pub struct FieldArgs {
     pub ident: Option<Ident>,
     pub ty: Type,
+    /// `#[inspect(skip)]`
+    ///
+    /// Do not expose property info
+    #[darling(default)]
+    pub skip: bool,
+    /// #[inspect(name = "<name>")]
+    ///
+    /// Name override for a field (default: UPPER_SNAKE)
+    #[darling(default)]
+    pub name: Option<String>,
+    /// #[inspect(group = "<group>")]
+    ///
+    /// Group override for a field (default: Common)
+    #[darling(default)]
+    pub group: Option<String>,
 }
 
 #[derive(FromVariant)]

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -34,6 +34,9 @@ pub struct FieldArgs {
     /// Group override for a field (default: Common)
     #[darling(default)]
     pub group: Option<String>,
+    /// `#[inspect(expand)]`
+    #[darling(default)]
+    pub expand: bool,
 }
 
 #[derive(FromVariant)]

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -26,7 +26,7 @@ pub struct FieldArgs {
     pub skip: bool,
     /// #[inspect(name = "<name>")]
     ///
-    /// Name override for a field (default: UPPER_SNAKE)
+    /// Name override for a field (default: Title Case)
     #[darling(default)]
     pub name: Option<String>,
     /// #[inspect(group = "<group>")]

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -1,0 +1,29 @@
+//! Derive input types by `darling`.
+//!
+//! They parse `#[attributes(..)]` in declartive style, different from `syn`.
+
+use darling::*;
+use syn::*;
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(visit), supports(struct_any, enum_any))]
+pub struct TypeArgs {
+    pub ident: Ident,
+    pub generics: Generics,
+    pub data: ast::Data<VariantArgs, FieldArgs>,
+}
+
+/// Parsed from struct's or enum variant's field
+#[derive(FromField, Clone)]
+#[darling(attributes(visit))]
+pub struct FieldArgs {
+    pub ident: Option<Ident>,
+    pub ty: Type,
+}
+
+#[derive(FromVariant)]
+#[darling(attributes(inspect))]
+pub struct VariantArgs {
+    pub ident: Ident,
+    pub fields: ast::Fields<FieldArgs>,
+}

--- a/rg3d-core-derive/src/inspect/utils.rs
+++ b/rg3d-core-derive/src/inspect/utils.rs
@@ -1,0 +1,75 @@
+use darling::ast;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::*;
+use syn::*;
+
+use convert_case::*;
+
+use crate::inspect::args;
+
+/// Creates `impl Inspect` block for struct type
+pub fn create_impl(
+    ty_args: &args::TypeArgs,
+    field_args: impl Iterator<Item = args::FieldArgs>,
+    impl_body: TokenStream2,
+) -> TokenStream2 {
+    let ty_ident = &ty_args.ident;
+    let generics = self::create_impl_generics(&ty_args.generics, field_args);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics Inspect for #ty_ident #ty_generics #where_clause {
+            fn properties(&self) -> Vec<PropertyInfo<'_>> {
+                #impl_body
+            }
+        }
+    }
+}
+
+/// Creates where clause for `impl Inspect` block
+fn create_impl_generics(
+    generics: &Generics,
+    _field_args: impl Iterator<Item = args::FieldArgs>,
+) -> Generics {
+    let generics = generics.clone();
+
+    // add boundaries if nessesary
+
+    generics
+}
+
+pub fn create_field_properties<'a>(
+    // <self.> or <variant.>
+    prefix: TokenStream2,
+    fields: impl Iterator<Item = &'a args::FieldArgs>,
+    field_style: ast::Style,
+) -> Vec<TokenStream2> {
+    assert_eq!(
+        field_style,
+        ast::Style::Struct,
+        "#[derive(Inspect)] handles only named fields for now"
+    );
+
+    let mut bodies = vec![];
+
+    for field in fields {
+        // we know it is named field
+        let field_ident = field.ident.as_ref().unwrap();
+
+        let field_name = field_ident.to_string().to_case(Case::UpperSnake);
+        let group = "Common";
+        let value = quote! { #prefix #field_ident };
+
+        let body = quote! {
+            PropertyInfo {
+                name: #field_name,
+                group: #group,
+                value: &#value,
+            }
+        };
+
+        bodies.push(body);
+    }
+
+    bodies
+}

--- a/rg3d-core-derive/src/inspect/utils.rs
+++ b/rg3d-core-derive/src/inspect/utils.rs
@@ -52,12 +52,21 @@ pub fn create_field_properties<'a>(
 
     let mut bodies = vec![];
 
-    for field in fields {
+    // consider #[inspect(skip)]
+    for field in fields.filter(|f| !f.skip) {
         // we know it is named field
         let field_ident = field.ident.as_ref().unwrap();
 
-        let field_name = field_ident.to_string().to_case(Case::UpperSnake);
-        let group = "Common";
+        // consider #[inspect(name = ..)]
+        let field_name = field
+            .name
+            .clone()
+            .unwrap_or_else(|| field_ident.to_string());
+        let field_name = field_name.to_case(Case::UpperSnake);
+
+        // consider #[inspect(group = ..)]
+        let group = field.group.as_ref().map(|s| s.as_str()).unwrap_or("Common");
+
         let value = quote! { #prefix #field_ident };
 
         let body = quote! {

--- a/rg3d-core-derive/src/inspect/utils.rs
+++ b/rg3d-core-derive/src/inspect/utils.rs
@@ -63,7 +63,7 @@ pub fn collect_field_props<'a>(
             .name
             .clone()
             .unwrap_or_else(|| field_ident.to_string());
-        let field_name = field_name.to_case(Case::UpperSnake);
+        let field_name = field_name.to_case(Case::Title);
 
         // consider #[inspect(group = ..)]
         let group = field.group.as_ref().map(|s| s.as_str()).unwrap_or("Common");

--- a/rg3d-core-derive/src/lib.rs
+++ b/rg3d-core-derive/src/lib.rs
@@ -1,3 +1,4 @@
+mod inspect;
 mod visit;
 
 use proc_macro::TokenStream;
@@ -10,4 +11,13 @@ use syn::{parse_macro_input, DeriveInput};
 pub fn visit(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     TokenStream::from(visit::impl_visit(ast))
+}
+
+/// Implements `Inspect` trait
+///
+/// User has to import `Inspect`.
+#[proc_macro_derive(Inspect, attributes(inspect))]
+pub fn inspect(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(inspect::impl_inspect(ast))
 }

--- a/rg3d-core-derive/src/visit/args.rs
+++ b/rg3d-core-derive/src/visit/args.rs
@@ -20,15 +20,21 @@ pub struct FieldArgs {
     pub ty: Type,
     // pub attrs: Vec<Attribute>,
     // ---
-    /// `#[visit(skip)]`: skip on read and write
+    /// `#[visit(skip)]`
+    ///
+    /// Skip on read and write
     #[darling(default)]
     pub skip: bool,
 
-    /// `#[visit(rename = "..")]`: force reading/writing as this name
+    /// `#[visit(rename = "..")]`
+    ///
+    /// Force this name
     #[darling(default)]
     pub rename: Option<String>,
 
-    /// `#[visit(optional)]`: ignore missing field
+    /// `#[visit(optional)]`
+    ///
+    /// Ignore missing field
     #[darling(default)]
     pub optional: bool,
 }

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -1,0 +1,32 @@
+//! Test cases for `rg3d::gui::Inspect`
+
+use rg3d_core::inspect::{Inspect, PropertyInfo};
+
+#[test]
+fn inspect_default() {
+    #[derive(Inspect)]
+    pub struct A {
+        the_field: String,
+        another_field: f32,
+    }
+
+    let a = A {
+        the_field: "Name!".to_string(),
+        another_field: 100.0,
+    };
+
+    let expected = vec![
+        PropertyInfo {
+            name: "THE_FIELD",
+            group: "Common",
+            value: &a.the_field,
+        },
+        PropertyInfo {
+            name: "ANOTHER_FIELD",
+            group: "Common",
+            value: &a.another_field,
+        },
+    ];
+
+    assert_eq!(a.properties(), expected);
+}

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -1,6 +1,9 @@
 //! Test cases for `rg3d::gui::Inspect`
 
-use rg3d_core::inspect::{Inspect, PropertyInfo};
+use rg3d_core::{
+    algebra::Vector3,
+    inspect::{Inspect, PropertyInfo},
+};
 
 #[test]
 fn inspect_default() {
@@ -25,6 +28,40 @@ fn inspect_default() {
             name: "ANOTHER_FIELD",
             group: "Common",
             value: &a.another_field,
+        },
+    ];
+
+    assert_eq!(a.properties(), expected);
+}
+
+#[test]
+fn inspect_attributes() {
+    #[derive(Inspect)]
+    pub struct A {
+        #[inspect(skip)]
+        skipped: Vector3<f32>,
+        #[inspect(group = "Pos")]
+        x: f32,
+        #[inspect(group = "Pos")]
+        y: f32,
+    }
+
+    let a = A {
+        skipped: Default::default(),
+        x: 10.0,
+        y: 20.0,
+    };
+
+    let expected = vec![
+        PropertyInfo {
+            name: "X",
+            group: "Pos",
+            value: &a.x,
+        },
+        PropertyInfo {
+            name: "Y",
+            group: "Pos",
+            value: &a.y,
         },
     ];
 

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -16,12 +16,12 @@ fn inspect_default() {
 
     let expected = vec![
         PropertyInfo {
-            name: "THE_FIELD",
+            name: "The Field",
             group: "Common",
             value: &data.the_field,
         },
         PropertyInfo {
-            name: "ANOTHER_FIELD",
+            name: "Another Field",
             group: "Common",
             value: &data.another_field,
         },
@@ -36,7 +36,7 @@ fn inspect_attributes() {
     pub struct Data {
         #[inspect(skip)]
         skipped: u32,
-        #[inspect(group = "Pos", name = "Super_X")]
+        #[inspect(group = "Pos", name = "Super X")]
         x: f32,
         // Expand properties are added to the end of the list
         #[inspect(expand)]
@@ -49,7 +49,7 @@ fn inspect_attributes() {
 
     let expected = vec![
         PropertyInfo {
-            name: "SUPER_X",
+            name: "Super X",
             group: "Pos",
             value: &data.x,
         },

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -1,69 +1,65 @@
 //! Test cases for `rg3d::gui::Inspect`
 
-use rg3d_core::{
-    algebra::Vector3,
-    inspect::{Inspect, PropertyInfo},
-};
+use rg3d_core::inspect::{Inspect, PropertyInfo};
+
+use rg3d::scene::transform::Transform;
 
 #[test]
 fn inspect_default() {
-    #[derive(Inspect)]
-    pub struct A {
+    #[derive(Default, Inspect)]
+    pub struct Data {
         the_field: String,
         another_field: f32,
     }
 
-    let a = A {
-        the_field: "Name!".to_string(),
-        another_field: 100.0,
-    };
+    let data = Data::default();
 
     let expected = vec![
         PropertyInfo {
             name: "THE_FIELD",
             group: "Common",
-            value: &a.the_field,
+            value: &data.the_field,
         },
         PropertyInfo {
             name: "ANOTHER_FIELD",
             group: "Common",
-            value: &a.another_field,
+            value: &data.another_field,
         },
     ];
 
-    assert_eq!(a.properties(), expected);
+    assert_eq!(data.properties(), expected);
 }
 
 #[test]
 fn inspect_attributes() {
-    #[derive(Inspect)]
-    pub struct A {
+    #[derive(Default, Inspect)]
+    pub struct Data {
         #[inspect(skip)]
-        skipped: Vector3<f32>,
-        #[inspect(group = "Pos")]
+        skipped: u32,
+        #[inspect(group = "Pos", name = "Super_X")]
         x: f32,
+        // Expand properties are added to the end of the list
+        #[inspect(expand)]
+        tfm: Transform,
         #[inspect(group = "Pos")]
         y: f32,
     }
 
-    let a = A {
-        skipped: Default::default(),
-        x: 10.0,
-        y: 20.0,
-    };
+    let data = Data::default();
 
     let expected = vec![
         PropertyInfo {
-            name: "X",
+            name: "SUPER_X",
             group: "Pos",
-            value: &a.x,
+            value: &data.x,
         },
         PropertyInfo {
             name: "Y",
             group: "Pos",
-            value: &a.y,
+            value: &data.y,
         },
     ];
 
-    assert_eq!(a.properties(), expected);
+    assert_eq!(data.properties()[0..2], expected);
+    assert_eq!(data.properties().len(), 2 + data.tfm.properties().len());
 }

--- a/rg3d-core-derive/tests/it/main.rs
+++ b/rg3d-core-derive/tests/it/main.rs
@@ -1,0 +1,5 @@
+//! The only integration test (the only test "crate")
+//!
+//! c.f. https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
+
+pub mod visit;

--- a/rg3d-core-derive/tests/it/main.rs
+++ b/rg3d-core-derive/tests/it/main.rs
@@ -2,5 +2,9 @@
 //!
 //! c.f. https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 
-pub mod inspect;
+#![feature(trace_macros)]
+
 pub mod visit;
+
+trace_macros!(true);
+pub mod inspect;

--- a/rg3d-core-derive/tests/it/main.rs
+++ b/rg3d-core-derive/tests/it/main.rs
@@ -2,4 +2,5 @@
 //!
 //! c.f. https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 
+pub mod inspect;
 pub mod visit;

--- a/rg3d-core-derive/tests/it/visit.rs
+++ b/rg3d-core-derive/tests/it/visit.rs
@@ -1,4 +1,7 @@
-//! Test utilities used by other files
+//! Test cases
+
+mod basic;
+mod compat;
 
 use std::{env, fs::File, io::Write, path::PathBuf};
 

--- a/rg3d-core-derive/tests/it/visit/basic.rs
+++ b/rg3d-core-derive/tests/it/visit/basic.rs
@@ -1,7 +1,5 @@
 #![allow(unused_imports)]
 
-mod utils;
-
 use std::{env, fs::File, io::Write, path::PathBuf};
 
 use futures::executor::block_on;
@@ -77,7 +75,7 @@ fn named_fields() {
     };
     let mut data_default = NamedFields::default();
 
-    utils::save_load("named_fields", &mut data, &mut data_default);
+    super::save_load("named_fields", &mut data, &mut data_default);
 
     // The default data was overwritten with saved data.
     // Now it should be same as the original data:
@@ -91,7 +89,7 @@ fn unit_struct() {
 
     // non seuse.. but anyways,
     // `Visit` is implemented `UnitStruct;` as empty code block `{}`
-    utils::save_load("unit_struct", &mut data, &mut data_default);
+    super::save_load("unit_struct", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }
@@ -101,7 +99,7 @@ fn tuple_struct() {
     let mut data = TupleStruct(10.0, 20);
     let mut data_default = TupleStruct(0.0, 0);
 
-    utils::save_load("tuple_struct", &mut data, &mut data_default);
+    super::save_load("tuple_struct", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }
@@ -114,7 +112,7 @@ fn skip_attr() {
     };
     let mut data_default = SkipAttr::default();
 
-    utils::save_load("skip_attr", &mut data, &mut data_default);
+    super::save_load("skip_attr", &mut data, &mut data_default);
 
     // The default data was overwritten with saved data,
     // except the `skipped` field:
@@ -146,7 +144,7 @@ fn generics() {
     };
     let mut data_default = Generics { items: vec![] };
 
-    utils::save_load("generics", &mut data, &mut data_default);
+    super::save_load("generics", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }
@@ -156,7 +154,7 @@ fn plain_enum() {
     let mut data = PlainEnum::C;
     let mut data_default = PlainEnum::A;
 
-    utils::save_load("plain_enum", &mut data, &mut data_default);
+    super::save_load("plain_enum", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }
@@ -169,7 +167,7 @@ fn one_of_the_types() {
     });
     let mut data_default = OneOfTheTypes::U32(0);
 
-    utils::save_load("one_of_the_types", &mut data, &mut data_default);
+    super::save_load("one_of_the_types", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }
@@ -179,7 +177,7 @@ fn complex_enum() {
     let mut data = ComplexEnum::Tuple(100, 200);
     let mut data_default = ComplexEnum::UnitVariant;
 
-    utils::save_load("complex_enum", &mut data, &mut data_default);
+    super::save_load("complex_enum", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }
@@ -199,7 +197,7 @@ fn generic_enum() {
     let mut data = GenericEnum::Tuple(1, vec![100u32]);
     let mut data_default = GenericEnum::UnitVariant;
 
-    utils::save_load("generic_enum", &mut data, &mut data_default);
+    super::save_load("generic_enum", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }

--- a/rg3d-core-derive/tests/it/visit/compat.rs
+++ b/rg3d-core-derive/tests/it/visit/compat.rs
@@ -1,10 +1,8 @@
 //! Fight the compatibility hell with attributes! .. someday :)
 
-mod utils;
-
 use rg3d_core::visitor::prelude::*;
 
-// Comment out to make sure it panics
+// Comment it out and make sure it panics
 // #[derive(Debug, Clone, PartialEq, Visit)]
 // pub struct CantCompile {
 //     pub a: f32,
@@ -23,7 +21,7 @@ fn rename() {
     let mut data = Rename { x: 100.0 };
     let mut data_default = Rename { x: 0.0 };
 
-    utils::save_load("rename", &mut data, &mut data_default);
+    super::save_load("rename", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }

--- a/rg3d-core/src/inspect.rs
+++ b/rg3d-core/src/inspect.rs
@@ -1,6 +1,7 @@
 use std::{
     any::{Any, TypeId},
-    fmt::Debug,
+    cmp::PartialEq,
+    fmt::{self, Debug},
 };
 
 pub trait PropertyValue: Any + Send + Sync + Debug {
@@ -28,6 +29,24 @@ pub struct PropertyInfo<'a> {
     pub value: &'a dyn PropertyValue,
 }
 
+impl<'a> fmt::Debug for PropertyInfo<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PropertyInfo")
+            .field("name", &self.name)
+            .field("group", &self.group)
+            .field("value", &format_args!("{:?}", self.value as *const _))
+            .finish()
+    }
+}
+
+impl<'a> PartialEq<Self> for PropertyInfo<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.group == other.group
+            && self.value as *const _ == other.value as *const _
+    }
+}
+
 impl<'a> PropertyInfo<'a> {
     pub fn cast_value<T: 'static>(&self) -> Result<&T, CastError> {
         match self.value.as_any().downcast_ref::<T>() {
@@ -44,3 +63,5 @@ impl<'a> PropertyInfo<'a> {
 pub trait Inspect {
     fn properties(&self) -> Vec<PropertyInfo<'_>>;
 }
+
+pub use rg3d_core_derive::Inspect;


### PR DESCRIPTION
Closes #186

# Example use

From [tests/it/inspect.rs](https://github.com/toyboot4e/rg3d/blob/inspect-derive/rg3d-core-derive/tests/it/inspect.rs):

```rust
use rg3d::{
    // maybe add `prelude`?
    core::inspector::{Inspect, ProprertyInfo},
    scene::transform::Transform,
};

#[test]
fn inspect_attributes() {
    #[derive(Default, Inspect)]
    pub struct Data {
        #[inspect(skip)]
        skipped: u32,

        #[inspect(group = "Pos", name = "Super X")]
        x: f32,

        #[inspect(expand)]
        tfm: Transform,

        #[inspect(group = "Pos")]
        y: f32,
    }

    let data = Data::default();

    let expected = vec![
        PropertyInfo {
            name: "Super X",
            group: "Pos",
            value: &data.x,
        },
        PropertyInfo {
            name: "Y",
            group: "Pos",
            value: &data.y,
        },
    ];

    assert_eq!(data.properties()[0..2], expected);
    assert_eq!(data.properties().len(), 2 + data.tfm.properties().len());
}
```

# PR contents

## Preparation
- [x] Restructuring `tests/`  for modulability and to reduce the number of test crates.  
c.f. [Delete Cargo Integration Tests](https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html)
- [x] Implement `Debug` and `PartialEq` for `PropertyInfo` (for `assert_eq!` in later tests)

## Requested features in #186
- [x] Support `Struct { named_field: value }`
- [x] `#[inspect(skip)]`
- [x] `#[inspect(name = ..)]`
- [x] `#[inspect(group = ..)]`

## More
- [x] `#[inspect(expand)]`

# TODOs
* Supporting other kinds of structs and enums.
* Improving the `Inspect` trait for performance (if necessary)
* (Just some refactoring to `#[derive(Visit)]`)