### PR TITLE
Refactor `#[derive(Visit)]`

### DIFF
--- a/rg3d-core-derive/src/inspect/utils.rs
+++ b/rg3d-core-derive/src/inspect/utils.rs
@@ -7,7 +7,7 @@ use convert_case::*;
 
 use crate::inspect::args;
 
-/// Creates `impl Inspect` block for struct type
+/// Creates `impl Inspect` block
 pub fn create_impl(
     ty_args: &args::TypeArgs,
     field_args: impl Iterator<Item = args::FieldArgs>,
@@ -26,7 +26,7 @@ pub fn create_impl(
     }
 }
 
-/// Creates where clause for `impl Inspect` block
+/// Creates `Generic` for `impl Inspect` block
 fn create_impl_generics(
     generics: &Generics,
     _field_args: impl Iterator<Item = args::FieldArgs>,
@@ -38,7 +38,7 @@ fn create_impl_generics(
     generics
 }
 
-/// List of `PropetiesInfo { .. }`
+/// List of `PropertyInfo { .. }`
 pub fn collect_field_props<'a>(
     // <self.> or <variant.>
     prefix: TokenStream2,
@@ -55,7 +55,7 @@ pub fn collect_field_props<'a>(
 
     // consider #[inspect(skip)]
     for field in fields.filter(|f| !f.skip && !f.expand) {
-        // we know it is named field
+        // we know it is a named field
         let field_ident = field.ident.as_ref().unwrap();
 
         // consider #[inspect(name = ..)]
@@ -86,7 +86,7 @@ pub fn collect_field_props<'a>(
 
 /// List of `field.properties()` for each `#[inspect(expand)]` field
 pub fn collect_field_prop_calls<'a>(
-    // <self.> or <variant.>
+    // `self.` or `variant.`
     prefix: TokenStream2,
     fields: impl Iterator<Item = &'a args::FieldArgs>,
     field_style: ast::Style,
@@ -100,7 +100,7 @@ pub fn collect_field_prop_calls<'a>(
     let mut expands = Vec::new();
 
     for field in fields.filter(|f| !f.skip && f.expand) {
-        // we know it is named field
+        // we know it is a named field
         let field_ident = field.ident.as_ref().unwrap();
 
         expands.push(quote! {

--- a/rg3d-core-derive/src/lib.rs
+++ b/rg3d-core-derive/src/lib.rs
@@ -6,7 +6,7 @@ use syn::{parse_macro_input, DeriveInput};
 
 /// Implements `Visit` trait
 ///
-/// User has to import `Visit`, `Visitor` and `VisitResult`.
+/// User has to import `Visit`, `Visitor` and `VisitResult` to use this macro.
 #[proc_macro_derive(Visit, attributes(visit))]
 pub fn visit(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -15,7 +15,7 @@ pub fn visit(input: TokenStream) -> TokenStream {
 
 /// Implements `Inspect` trait
 ///
-/// User has to import `Inspect`.
+/// User has to import `Inspect` and `PropertyInfo` to use this macro.
 #[proc_macro_derive(Inspect, attributes(inspect))]
 pub fn inspect(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/rg3d-core-derive/src/visit.rs
+++ b/rg3d-core-derive/src/visit.rs
@@ -1,8 +1,6 @@
 mod args;
+mod utils;
 
-use std::collections::HashSet;
-
-use convert_case::{Case, Casing};
 use darling::*;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::*;
@@ -10,128 +8,24 @@ use syn::*;
 
 // impl `#[derive(Visit)]` for `struct` or `enum`
 pub fn impl_visit(ast: DeriveInput) -> TokenStream2 {
-    let args = args::TypeArgs::from_derive_input(&ast).unwrap();
-    match &args.data {
-        ast::Data::Struct(ref field_args) => self::impl_visit_struct(&args, field_args),
-        ast::Data::Enum(ref variants) => self::impl_visit_enum(&args, variants),
+    let ty_args = args::TypeArgs::from_derive_input(&ast).unwrap();
+    match &ty_args.data {
+        ast::Data::Struct(ref field_args) => self::impl_visit_struct(&ty_args, field_args),
+        ast::Data::Enum(ref variants) => self::impl_visit_enum(&ty_args, variants),
     }
-}
-
-fn create_generics(
-    generics: &Generics,
-    field_args: impl Iterator<Item = args::FieldArgs>,
-) -> Generics {
-    let mut generics = generics.clone();
-
-    // Add where clause for every visited field
-    generics.make_where_clause().predicates.extend(
-        field_args
-            .filter(|f| !f.skip)
-            .map(|f| f.ty)
-            .map::<WherePredicate, _>(|ty| parse_quote! { #ty: Visit }),
-    );
-
-    generics
-}
-
-/// `<prefix>field.visit("name", visitor);`
-fn create_field_visits<'a>(
-    // None or `f` when bindings tuple variants. NOTE: We can't use `prefix: Ident`
-    prefix: Option<Ident>,
-    fields: impl Iterator<Item = &'a args::FieldArgs>,
-    field_style: ast::Style,
-) -> Vec<TokenStream2> {
-    if field_style == ast::Style::Unit {
-        // `Unit` (struct/enum variant) has no field to visit.
-        // We won't even enter this region:
-        return vec![];
-    }
-
-    let visit_args = fields
-        .filter(|field| !field.skip)
-        .enumerate()
-        .map(|(field_index, field)| {
-            let (ident, name) = match field_style {
-                // `NamedFields { a: f32, .. }`
-                ast::Style::Struct => {
-                    let ident = field.ident.as_ref().unwrap_or_else(|| unreachable!());
-
-                    (
-                        quote!(#ident),
-                        format!("{}", ident).to_case(Case::UpperCamel),
-                    )
-                }
-                // `Tuple(f32, ..)`
-                ast::Style::Tuple => {
-                    let ident = Index::from(field_index);
-
-                    let ident = match prefix {
-                        Some(ref prefix) => {
-                            let ident = format_ident!("{}{}", prefix, ident);
-                            quote!(#ident)
-                        }
-                        None => quote!(#ident),
-                    };
-
-                    (ident, format!("{}", field_index))
-                }
-                ast::Style::Unit => unreachable!(),
-            };
-
-            let name = match &field.rename {
-                Some(new_name) => {
-                    assert!(
-                        !new_name.is_empty(),
-                        "renaming to empty string doesn't make sense!"
-                    );
-                    // overwrite the field name with the specified name:
-                    new_name.clone()
-                }
-                None => name,
-            };
-
-            (ident, name, field.optional)
-        })
-        .collect::<Vec<_>>();
-
-    let mut no_dup = HashSet::new();
-    for name in visit_args.iter().map(|(_, name, _)| name) {
-        if !no_dup.insert(name) {
-            panic!("duplicate visiting names detected!");
-        }
-    }
-
-    visit_args
-        .iter()
-        .map(|(ident, name, optional)| {
-            if *optional {
-                quote! {
-                    #ident.visit(#name, visitor).ok();
-                }
-            } else {
-                quote! {
-                    #ident.visit(#name, visitor)?;
-                }
-            }
-        })
-        .collect::<Vec<_>>()
 }
 
 /// impl `Visit` for `struct`
 fn impl_visit_struct(
-    args: &args::TypeArgs,
+    ty_args: &args::TypeArgs,
     field_args: &ast::Fields<args::FieldArgs>,
 ) -> TokenStream2 {
-    let ty_ident = &args.ident;
-    let generics = self::create_generics(&args.generics, field_args.iter().cloned());
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
     let visit_fn_body = if field_args.style == ast::Style::Unit {
         quote! { Ok(()) }
     } else {
         // `field.visit(..);` parts
         let field_visits =
-            self::create_field_visits(None, field_args.fields.iter(), field_args.style);
+            utils::create_field_visits(None, field_args.fields.iter(), field_args.style);
 
         quote! {
             visitor.enter_region(name)?;
@@ -140,24 +34,12 @@ fn impl_visit_struct(
         }
     };
 
-    quote! {
-        impl #impl_generics Visit for #ty_ident #ty_generics #where_clause {
-            fn visit(
-                &mut self,
-                #[allow(unused)]
-                name: &str,
-                #[allow(unused)]
-                visitor: &mut Visitor,
-            ) -> VisitResult {
-                #visit_fn_body
-            }
-        }
-    }
+    utils::create_impl(ty_args, field_args.iter().cloned(), visit_fn_body)
 }
 
 /// impl `Visit` for `enum`
-fn impl_visit_enum(args: &args::TypeArgs, variants: &[args::VariantArgs]) -> TokenStream2 {
-    let ty_ident = &args.ident;
+fn impl_visit_enum(ty_args: &args::TypeArgs, variant_args: &[args::VariantArgs]) -> TokenStream2 {
+    let ty_ident = &ty_args.ident;
     let ty_name = format!("{}", ty_ident);
 
     // variant ID = variant index
@@ -165,28 +47,31 @@ fn impl_visit_enum(args: &args::TypeArgs, variants: &[args::VariantArgs]) -> Tok
 
     // `fn id(&self) -> u32`
     let fn_id = {
-        let matchers = variants.iter().enumerate().map(|(variant_index, variant)| {
-            let variant_index = variant_index as u32;
-            let variant_ident = &variant.ident;
+        let matchers = variant_args
+            .iter()
+            .enumerate()
+            .map(|(variant_index, variant)| {
+                let variant_index = variant_index as u32;
+                let variant_ident = &variant.ident;
 
-            match variant.fields.style {
-                ast::Style::Struct => quote! {
-                    #ty_ident::#variant_ident { .. } => #variant_index,
-                },
-                ast::Style::Tuple => {
-                    let idents = (0..variant.fields.len()).map(|__| quote!(_));
+                match variant.fields.style {
+                    ast::Style::Struct => quote! {
+                        #ty_ident::#variant_ident { .. } => #variant_index,
+                    },
+                    ast::Style::Tuple => {
+                        let idents = (0..variant.fields.len()).map(|__| quote!(_));
 
-                    quote! {
-                        #ty_ident::#variant_ident(#(#idents),*) => #variant_index,
+                        quote! {
+                            #ty_ident::#variant_ident(#(#idents),*) => #variant_index,
+                        }
                     }
+                    ast::Style::Unit => quote! {
+                        #ty_ident::#variant_ident => #variant_index,
+                    },
                 }
-                ast::Style::Unit => quote! {
-                    #ty_ident::#variant_ident => #variant_index,
-                },
-            }
-        });
+            });
 
-        let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
+        let (impl_generics, ty_generics, where_clause) = ty_args.generics.split_for_impl();
 
         quote! {
             fn id #impl_generics (me: &#ty_ident #ty_generics) -> #id_type #where_clause {
@@ -201,47 +86,50 @@ fn impl_visit_enum(args: &args::TypeArgs, variants: &[args::VariantArgs]) -> Tok
     // `fn from_id(id: u32) -> Result<Self, String>`
     let fn_from_id = {
         // `<variant_index> => Ok(TypeName::Variant(Default::default())),
-        let matchers = variants.iter().enumerate().map(|(variant_index, variant)| {
-            let variant_index = variant_index as u32;
-            let variant_ident = &variant.ident;
+        let matchers = variant_args
+            .iter()
+            .enumerate()
+            .map(|(variant_index, variant)| {
+                let variant_index = variant_index as u32;
+                let variant_ident = &variant.ident;
 
-            // create default value of this variant
-            let default = match variant.fields.style {
-                ast::Style::Struct => {
-                    let defaults = variant.fields.iter().map(|field| {
-                        let field_ident = &field.ident;
+                // create default value of this variant
+                let default = match variant.fields.style {
+                    ast::Style::Struct => {
+                        let defaults = variant.fields.iter().map(|field| {
+                            let field_ident = &field.ident;
+                            quote! {
+                                #field_ident: Default::default(),
+                            }
+                        });
+
                         quote! {
-                            #field_ident: Default::default(),
+                            #ty_ident::#variant_ident {
+                                #(#defaults)*
+                            },
                         }
-                    });
-
-                    quote! {
-                        #ty_ident::#variant_ident {
-                            #(#defaults)*
-                        },
                     }
-                }
-                ast::Style::Tuple => {
-                    let defaults = variant
-                        .fields
-                        .iter()
-                        .map(|_| quote! { Default::default(), });
+                    ast::Style::Tuple => {
+                        let defaults = variant
+                            .fields
+                            .iter()
+                            .map(|_| quote! { Default::default(), });
 
-                    quote! {
-                        #ty_ident::#variant_ident(#(#defaults)*),
+                        quote! {
+                            #ty_ident::#variant_ident(#(#defaults)*),
+                        }
                     }
+                    ast::Style::Unit => quote! {
+                        #ty_ident::#variant_ident
+                    },
+                };
+
+                quote! {
+                    id if id == #variant_index => Ok(#default),
                 }
-                ast::Style::Unit => quote! {
-                    #ty_ident::#variant_ident
-                },
-            };
+            });
 
-            quote! {
-                id if id == #variant_index => Ok(#default),
-            }
-        });
-
-        let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
+        let (impl_generics, ty_generics, where_clause) = ty_args.generics.split_for_impl();
 
         quote! {
             fn from_id #impl_generics (
@@ -258,13 +146,13 @@ fn impl_visit_enum(args: &args::TypeArgs, variants: &[args::VariantArgs]) -> Tok
     };
 
     // visit every field of each variant
-    let variant_visits = variants.iter().map(|variant| {
+    let variant_visits = variant_args.iter().map(|variant| {
         let (fields, style) = (&variant.fields, variant.fields.style);
         let variant_ident = &variant.ident;
 
         match style {
             ast::Style::Struct => {
-                let field_visits = self::create_field_visits(None, fields.iter(), style);
+                let field_visits = utils::create_field_visits(None, fields.iter(), style);
 
                 let idents = fields.iter().map(|field| {
                     let ident = &field.ident;
@@ -278,7 +166,8 @@ fn impl_visit_enum(args: &args::TypeArgs, variants: &[args::VariantArgs]) -> Tok
                 }
             }
             ast::Style::Tuple => {
-                let field_visits = self::create_field_visits(parse_quote!(f), fields.iter(), style);
+                let field_visits =
+                    utils::create_field_visits(parse_quote!(f), fields.iter(), style);
 
                 let idents = (0..fields.len()).map(|i| format_ident!("f{}", Index::from(i)));
 
@@ -294,44 +183,28 @@ fn impl_visit_enum(args: &args::TypeArgs, variants: &[args::VariantArgs]) -> Tok
         }
     });
 
-    let generics = {
-        // fields of all the variants
-        let field_args = variants
-            .iter()
-            .flat_map(|variant| variant.fields.clone().into_iter());
+    utils::create_impl(
+        ty_args,
+        variant_args.iter().flat_map(|v| v.fields.iter()).cloned(),
+        quote! {
+             visitor.enter_region(name)?;
 
-        self::create_generics(&args.generics, field_args)
-    };
+             let mut id = id(self);
+             id.visit("Id", visitor)?;
 
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+             if visitor.is_reading() {
+                 *self = from_id(id)?;
+             }
 
-    // plain-enum-only support
-    quote! {
-        impl #impl_generics Visit for #ty_ident #ty_generics #where_clause {
-            fn visit(
-                &mut self,
-                name: &str,
-                visitor: &mut Visitor,
-            ) -> VisitResult {
-                visitor.enter_region(name)?;
+             match self {
+                 #(#variant_visits)*
+             }
 
-                let mut id = id(self);
-                id.visit("Id", visitor)?;
+             return visitor.leave_region();
 
-                if visitor.is_reading() {
-                    *self = from_id(id)?;
-                }
+             #fn_id
 
-                match self {
-                    #(#variant_visits)*
-                }
-
-                return visitor.leave_region();
-
-                #fn_id
-
-                #fn_from_id
-            }
-        }
-    }
+             #fn_from_id
+        },
+    )
 }

--- a/rg3d-core-derive/src/visit/utils.rs
+++ b/rg3d-core-derive/src/visit/utils.rs
@@ -1,0 +1,132 @@
+use std::collections::HashSet;
+
+use darling::ast;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::*;
+use syn::*;
+
+use convert_case::*;
+
+use crate::visit::args;
+
+pub fn create_impl(
+    ty_args: &args::TypeArgs,
+    field_args: impl Iterator<Item = args::FieldArgs>,
+    impl_body: TokenStream2,
+) -> TokenStream2 {
+    let ty_ident = &ty_args.ident;
+    let generics = self::create_impl_generics(&ty_args.generics, field_args);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics Visit for #ty_ident #ty_generics #where_clause {
+            fn visit(
+                &mut self,
+                name: &str,
+                visitor: &mut Visitor,
+            ) -> VisitResult {
+                #impl_body
+            }
+        }
+    }
+}
+
+fn create_impl_generics(
+    generics: &Generics,
+    field_args: impl Iterator<Item = args::FieldArgs>,
+) -> Generics {
+    let mut generics = generics.clone();
+
+    // Add where clause for every visited field
+    generics.make_where_clause().predicates.extend(
+        field_args
+            .filter(|f| !f.skip)
+            .map(|f| f.ty)
+            .map::<WherePredicate, _>(|ty| parse_quote! { #ty: Visit }),
+    );
+
+    generics
+}
+
+/// `<prefix>field.visit("name", visitor);`
+pub fn create_field_visits<'a>(
+    // None or `f` when bindings tuple variants. NOTE: We can't use `prefix: Ident`
+    prefix: Option<Ident>,
+    fields: impl Iterator<Item = &'a args::FieldArgs>,
+    field_style: ast::Style,
+) -> Vec<TokenStream2> {
+    if field_style == ast::Style::Unit {
+        // `Unit` (struct/enum variant) has no field to visit.
+        // We won't even enter this region:
+        return vec![];
+    }
+
+    let visit_args = fields
+        .filter(|field| !field.skip)
+        .enumerate()
+        .map(|(field_index, field)| {
+            let (ident, name) = match field_style {
+                // `NamedFields { a: f32, .. }`
+                ast::Style::Struct => {
+                    let ident = field.ident.as_ref().unwrap_or_else(|| unreachable!());
+
+                    (
+                        quote!(#ident),
+                        format!("{}", ident).to_case(Case::UpperCamel),
+                    )
+                }
+                // `Tuple(f32, ..)`
+                ast::Style::Tuple => {
+                    let ident = Index::from(field_index);
+
+                    let ident = match prefix {
+                        Some(ref prefix) => {
+                            let ident = format_ident!("{}{}", prefix, ident);
+                            quote!(#ident)
+                        }
+                        None => quote!(#ident),
+                    };
+
+                    (ident, format!("{}", field_index))
+                }
+                ast::Style::Unit => unreachable!(),
+            };
+
+            let name = match &field.rename {
+                Some(new_name) => {
+                    assert!(
+                        !new_name.is_empty(),
+                        "renaming to empty string doesn't make sense!"
+                    );
+                    // overwrite the field name with the specified name:
+                    new_name.clone()
+                }
+                None => name,
+            };
+
+            (ident, name, field.optional)
+        })
+        .collect::<Vec<_>>();
+
+    let mut no_dup = HashSet::new();
+    for name in visit_args.iter().map(|(_, name, _)| name) {
+        if !no_dup.insert(name) {
+            panic!("duplicate visiting names detected!");
+        }
+    }
+
+    visit_args
+        .iter()
+        .map(|(ident, name, optional)| {
+            if *optional {
+                quote! {
+                    #ident.visit(#name, visitor).ok();
+                }
+            } else {
+                quote! {
+                    #ident.visit(#name, visitor)?;
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+}

--- a/rg3d-core-derive/tests/it/main.rs
+++ b/rg3d-core-derive/tests/it/main.rs
@@ -2,9 +2,9 @@
 //!
 //! c.f. https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 
-#![feature(trace_macros)]
+// #![feature(trace_macros)]
 
 pub mod visit;
 
-trace_macros!(true);
+// trace_macros!(true);
 pub mod inspect;


### PR DESCRIPTION
Hi 👋 It's just some refactoring and _should not_ change any `#[derive(Visit)]` output.

Contents:

* Renaming of variables + moving of functions
* Reducnig some lines of code with `visit::utils::create_impl`

`test_output` did not change after the commits, at least. This is the 2rd and the last refactoring I think 🙏 
