### PR TITLE
Add enum support for `#[derive(Inspect)]`

### DIFF
--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -65,7 +65,7 @@ struct Interface {
 }
 
 // User interface in the engine build up on graph data structure, on tree to be
-// more precise. Each UI element can has single parent and multiple children.
+// more precise. Each UI element can have single parent and multiple children.
 // UI uses complex layout system which automatically organizes your widgets.
 // In this example we'll use Grid and StackPanel layout controls. Grid can be
 // divided in rows and columns, its child element can set their desired column

--- a/rg3d-core-derive/Cargo.toml
+++ b/rg3d-core-derive/Cargo.toml
@@ -22,5 +22,4 @@ darling = "0.13.0"
 
 [dev-dependencies]
 rg3d-core = { path = "../rg3d-core" }
-rg3d = { path = "../" }
 futures = "0.3.16"

--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -5,7 +5,7 @@ mod utils;
 
 use darling::{ast, FromDeriveInput};
 use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::*;
 
 pub fn impl_inspect(ast: DeriveInput) -> TokenStream2 {
@@ -26,16 +26,67 @@ fn impl_inspect_struct(
         "#[derive(Inspect)] handles only named fields for now"
     );
 
-    let body = utils::gen_inspect_fn_body(ty_args, quote! { self. }, field_args);
-    utils::create_impl(ty_args, field_args.iter().cloned(), body)
+    let body = utils::gen_inspect_fn_body(ty_args, utils::FieldPrefix::Self_, field_args);
+    utils::create_impl(ty_args, field_args.iter(), body)
 }
 
-fn impl_inspect_enum(
-    _ty_args: &args::TypeArgs,
-    _variant_args: &[args::VariantArgs],
-) -> TokenStream2 {
-    todo!("#[derive(Inspect)] is only for structure types for now")
-    // bind each field
+fn impl_inspect_enum(ty_args: &args::TypeArgs, variant_args: &[args::VariantArgs]) -> TokenStream2 {
+    let variant_matches =
+        variant_args.iter().map(|variant| {
+            let variant_ident = &variant.ident;
 
-    // generate implementation
+            let field_prefix = if variant.fields.style == ast::Style::Struct {
+                utils::FieldPrefix::None
+            } else {
+                utils::FieldPrefix::F
+            };
+
+            let field_idents = variant.fields.fields.iter().enumerate().map(|(i, field)| {
+                match variant.fields.style {
+                    ast::Style::Struct => field.ident.clone().unwrap(),
+                    ast::Style::Tuple => {
+                        let i = Index::from(i);
+                        format_ident!("f{}", i)
+                    }
+                    ast::Style::Unit => {
+                        format_ident!("<unreachable>")
+                    }
+                }
+            });
+
+            let variant_match = match variant.fields.style {
+                ast::Style::Struct => {
+                    quote! {
+                        Self::#variant_ident { #(#field_idents),* }
+                    }
+                }
+                ast::Style::Tuple => {
+                    quote! {
+                        Self::#variant_ident(#(#field_idents),*)
+                    }
+                }
+                ast::Style::Unit => {
+                    quote! {
+                        Self::#variant_ident
+                    }
+                }
+            };
+
+            let fields_inspect = utils::gen_inspect_fn_body(ty_args, field_prefix, &variant.fields);
+
+            quote! {
+                #variant_match => {
+                    #fields_inspect
+                }
+            }
+        });
+
+    let body = quote! {
+        match self {
+            #(#variant_matches,)*
+        }
+    };
+
+    let field_args = variant_args.iter().flat_map(|v| v.fields.iter());
+    utils::create_impl(ty_args, field_args, body)
 }

--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -20,12 +20,6 @@ fn impl_inspect_struct(
     ty_args: &args::TypeArgs,
     field_args: &ast::Fields<args::FieldArgs>,
 ) -> TokenStream2 {
-    assert_eq!(
-        field_args.style,
-        ast::Style::Struct,
-        "#[derive(Inspect)] handles only named fields for now"
-    );
-
     let body = utils::gen_inspect_fn_body(ty_args, utils::FieldPrefix::Self_, field_args);
     utils::create_impl(ty_args, field_args.iter(), body)
 }

--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -23,47 +23,11 @@ fn impl_inspect_struct(
     assert_eq!(
         field_args.style,
         ast::Style::Struct,
-        "#[derive(Inspect) considers only named fields for now"
+        "#[derive(Inspect)] handles only named fields for now"
     );
 
-    let prop_vec = {
-        let props = utils::collect_field_props(
-            quote! {  self. },
-            ty_args.ident.to_string(),
-            field_args.fields.iter(),
-            field_args.style,
-        );
-
-        quote! {
-            vec![
-                #(
-                    #props,
-                )*
-            ]
-        }
-    };
-
-    // list of `self.expanded_field.prop()`
-    let prop_calls = utils::collect_field_prop_calls(
-        quote! {  self. },
-        field_args.fields.iter(),
-        field_args.style,
-    );
-
-    let impl_body = if prop_calls.is_empty() {
-        prop_vec
-    } else {
-        // NOTE: All items marked as `#[inspect(expand)]` come to the end of the property list
-        quote! {
-            let mut props = #prop_vec;
-            #(
-                props.extend(#prop_calls .into_iter());
-            )*
-            props
-        }
-    };
-
-    utils::create_impl(ty_args, field_args.iter().cloned(), impl_body)
+    let body = utils::gen_inspect_fn_body(ty_args, quote! { self. }, field_args);
+    utils::create_impl(ty_args, field_args.iter().cloned(), body)
 }
 
 fn impl_inspect_enum(
@@ -71,4 +35,7 @@ fn impl_inspect_enum(
     _variant_args: &[args::VariantArgs],
 ) -> TokenStream2 {
     todo!("#[derive(Inspect)] is only for structure types for now")
+    // bind each field
+
+    // generate implementation
 }

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -14,6 +14,9 @@ pub struct TypeArgs {
 }
 
 /// Parsed from struct's or enum variant's field
+///
+/// NOTE: `#[derive(Inspect)]` is non-recursive by default. The `expand` and `expand_subtree` make
+/// it different.
 #[derive(FromField, Clone)]
 #[darling(attributes(inspect))]
 pub struct FieldArgs {
@@ -62,5 +65,5 @@ pub struct FieldArgs {
 #[darling(attributes(inspect))]
 pub struct VariantArgs {
     pub ident: Ident,
-    pub field_args: ast::Fields<FieldArgs>,
+    pub fields: ast::Fields<FieldArgs>,
 }

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -15,8 +15,7 @@ pub struct TypeArgs {
 
 /// Parsed from struct's or enum variant's field
 ///
-/// NOTE: `#[derive(Inspect)]` is non-recursive by default. The `expand` and `expand_subtree` make
-/// it different.
+/// NOTE: `#[derive(Inspect)]` is non-recursive by default.
 #[derive(FromField, Clone)]
 #[darling(attributes(inspect))]
 pub struct FieldArgs {

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -46,20 +46,21 @@ pub struct FieldArgs {
     pub group: Option<String>,
 
     /// `#[inspect(expand)]`
+    ///
+    /// Include the fields of the field, exclude the marked field itself.
     #[darling(default)]
     pub expand: bool,
 
-    /// `#[inspect(include_self)]`
+    /// `#[inspect(expand_subtree)]`
     ///
-    /// Whether to generate property info for a field on expansion or not.
-    /// Useful for enumerations.
+    /// Include the field and the fields of the field.
     #[darling(default)]
-    pub include_self: bool,
+    pub expand_subtree: bool,
 }
 
 #[derive(FromVariant)]
 #[darling(attributes(inspect))]
 pub struct VariantArgs {
     pub ident: Ident,
-    pub fields: ast::Fields<FieldArgs>,
+    pub field_args: ast::Fields<FieldArgs>,
 }

--- a/rg3d-core-derive/src/inspect/utils.rs
+++ b/rg3d-core-derive/src/inspect/utils.rs
@@ -38,88 +38,95 @@ fn create_impl_generics(
     generics
 }
 
-/// List of `PropertyInfo { .. }`
-pub fn collect_field_props<'a>(
-    // <self.> or <variant.>
-    prefix: TokenStream2,
-    owner_name: String,
-    fields: impl Iterator<Item = &'a args::FieldArgs>,
-    field_style: ast::Style,
-) -> Vec<TokenStream2> {
-    assert_eq!(
-        field_style,
-        ast::Style::Struct,
-        "#[derive(Inspect)] handles only named fields for now"
-    );
+pub fn gen_inspect_fn_body(
+    ty_args: &args::TypeArgs,
+    field_prefix: TokenStream2,
+    field_args: &ast::Fields<args::FieldArgs>,
+) -> TokenStream2 {
+    let owner_name = ty_args.ident.to_string();
 
-    let mut bodies = Vec::new();
+    // `inspect` function body, consisting of a sequence of quotes
+    let mut quotes = Vec::new();
 
-    // consider #[inspect(skip)]
-    for field in fields.filter(|f| !f.skip && (!f.expand || f.include_self)) {
-        // we know it is a named field
-        let field_ident = field.ident.as_ref().unwrap();
+    // collect non-expanible field properties
+    let props = field_args
+        .fields
+        .iter()
+        .filter(|f| !f.skip && !(f.expand || f.expand_subtree))
+        .map(|field| self::quote_field_prop(&field_prefix, &owner_name, field));
 
-        // consider #[inspect(name = ..)]
-        let field_name = field
-            .name
-            .clone()
-            .unwrap_or_else(|| field_ident.to_string());
+    quotes.push(quote! {
+        let mut props = Vec::new();
+        #(props.push(#props);)*
+    });
 
-        // consider #[inspect(display_name = ..)]
-        let display_name = field
-            .display_name
-            .clone()
-            .unwrap_or_else(|| field_ident.to_string());
-        let display_name = display_name.to_case(Case::Title);
+    // visit expanible fields
+    for field in field_args
+        .fields
+        .iter()
+        .filter(|f| !f.skip && (f.expand || f.expand_subtree))
+    {
+        // parent (the field)
+        if field.expand_subtree {
+            let prop = self::quote_field_prop(&field_prefix, &owner_name, field);
+            quotes.push(quote! {
+                props.push(#prop);
+            });
+        }
 
-        // consider #[inspect(group = ..)]
-        let group = field
-            .group
-            .as_ref()
-            .map(|s| s.as_str())
-            .unwrap_or(owner_name.as_str());
-
-        let value = quote! { #prefix #field_ident };
-
-        let body = quote! {
-            PropertyInfo {
-                owner_type_id: std::any::TypeId::of::<Self>(),
-                name: #field_name,
-                display_name: #display_name,
-                group: #group,
-                value: &#value,
-            }
-        };
-
-        bodies.push(body);
-    }
-
-    bodies
-}
-
-/// List of `field.properties()` for each `#[inspect(expand)]` field
-pub fn collect_field_prop_calls<'a>(
-    // `self.` or `variant.`
-    prefix: TokenStream2,
-    fields: impl Iterator<Item = &'a args::FieldArgs>,
-    field_style: ast::Style,
-) -> Vec<TokenStream2> {
-    assert_eq!(
-        field_style,
-        ast::Style::Struct,
-        "#[derive(Inspect)] handles only named fields for now"
-    );
-
-    let mut expands = Vec::new();
-
-    for field in fields.filter(|f| !f.skip && f.expand) {
-        // we know it is a named field
-        let field_ident = field.ident.as_ref().unwrap();
-
-        expands.push(quote! {
-            #prefix #field_ident .properties()
+        // children (fields of the field)
+        let field_ident = field.ident.as_ref().expect("named field expected");
+        quotes.push(quote! {
+            props.extend(#field_prefix #field_ident .properties());
         });
     }
 
-    expands
+    // concatanate the quotes
+    quote! {
+        #(#quotes)*
+        props
+    }
+}
+
+fn quote_field_prop(
+    // `self.`, none or `f`
+    field_prefix: &TokenStream2,
+    // the name of the property owner, used as default property group
+    owner_name: &str,
+    field: &args::FieldArgs,
+) -> TokenStream2 {
+    // we know it is a named field
+    let field_ident = field.ident.as_ref().expect("named field expected");
+
+    // consider #[inspect(name = ..)]
+    let field_name = field
+        .name
+        .clone()
+        .unwrap_or_else(|| field_ident.to_string());
+
+    // consider #[inspect(display_name = ..)]
+    let display_name = field
+        .display_name
+        .clone()
+        .unwrap_or_else(|| field_ident.to_string());
+    let display_name = display_name.to_case(Case::Title);
+
+    // consider #[inspect(group = ..)]
+    let group = field
+        .group
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or(owner_name);
+
+    let value = quote! { #field_prefix #field_ident };
+
+    quote! {
+        PropertyInfo {
+            owner_type_id: std::any::TypeId::of::<Self>(),
+            name: #field_name,
+            display_name: #display_name,
+            group: #group,
+            value: &#value,
+        }
+    }
 }

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -7,7 +7,7 @@ use std::any::TypeId;
 
 #[test]
 fn inspect_default() {
-    #[derive(Default, Inspect)]
+    #[derive(Debug, Default, Inspect)]
     pub struct Data {
         the_field: String,
         another_field: f32,
@@ -37,10 +37,10 @@ fn inspect_default() {
 
 #[test]
 fn inspect_attributes() {
-    #[derive(Default, Inspect)]
+    #[derive(Debug, Default, Inspect)]
     pub struct Data {
         #[inspect(skip)]
-        skipped: u32,
+        _skipped: u32,
         #[inspect(group = "Pos", name = "the_x", display_name = "Super X")]
         x: f32,
         // Expand properties are added to the end of the list
@@ -71,4 +71,18 @@ fn inspect_attributes() {
 
     assert_eq!(data.properties()[0..2], expected);
     assert_eq!(data.properties().len(), 2 + data.tfm.properties().len());
+
+    #[derive(Debug, Default, Inspect)]
+    pub struct X {
+        #[inspect(expand_subtree)]
+        y: Y,
+    }
+
+    #[derive(Debug, Default, Inspect)]
+    pub struct Y {
+        a: u32,
+    }
+
+    let x = X::default();
+    assert_eq!(x.properties().len(), 1 + x.y.properties().len());
 }

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -93,6 +93,39 @@ fn inspect_attributes() {
 }
 
 #[test]
+fn inspect_struct() {
+    #[derive(Debug, Default, Inspect)]
+    struct Tuple(f32, f32);
+
+    let x = Tuple::default();
+    assert_eq!(
+        x.properties(),
+        vec![
+            PropertyInfo {
+                owner_type_id: TypeId::of::<Tuple>(),
+                name: "0",
+                display_name: "0",
+                group: "Tuple",
+                value: &x.0,
+            },
+            PropertyInfo {
+                owner_type_id: TypeId::of::<Tuple>(),
+                name: "1",
+                display_name: "1",
+                group: "Tuple",
+                value: &x.1
+            },
+        ]
+    );
+
+    #[derive(Debug, Default, Inspect)]
+    struct Unit;
+
+    let x = Unit::default();
+    assert_eq!(x.properties(), vec![]);
+}
+
+#[test]
 fn inspect_enum() {
     #[derive(Debug, Inspect)]
     pub struct NonCopy {

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -1,9 +1,8 @@
 //! Test cases for `rg3d::gui::Inspect`
 
-use rg3d_core::inspect::{Inspect, PropertyInfo};
-
-use rg3d::scene::transform::Transform;
 use std::any::TypeId;
+
+use rg3d_core::inspect::{Inspect, PropertyInfo};
 
 #[test]
 fn inspect_default() {
@@ -38,6 +37,12 @@ fn inspect_default() {
 #[test]
 fn inspect_attributes() {
     #[derive(Debug, Default, Inspect)]
+    pub struct AarGee {
+        aar: u32,
+        gee: u32,
+    }
+
+    #[derive(Debug, Default, Inspect)]
     pub struct Data {
         #[inspect(skip)]
         _skipped: u32,
@@ -45,7 +50,7 @@ fn inspect_attributes() {
         x: f32,
         // Expand properties are added to the end of the list
         #[inspect(expand)]
-        tfm: Transform,
+        aar_gee: AarGee,
         #[inspect(group = "Pos")]
         y: f32,
     }
@@ -70,7 +75,7 @@ fn inspect_attributes() {
     ];
 
     assert_eq!(data.properties()[0..2], expected);
-    assert_eq!(data.properties().len(), 2 + data.tfm.properties().len());
+    assert_eq!(data.properties().len(), 2 + data.aar_gee.properties().len());
 
     #[derive(Debug, Default, Inspect)]
     pub struct X {
@@ -85,4 +90,93 @@ fn inspect_attributes() {
 
     let x = X::default();
     assert_eq!(x.properties().len(), 1 + x.y.properties().len());
+}
+
+#[test]
+fn inspect_enum() {
+    #[derive(Debug, Inspect)]
+    pub struct NonCopy {
+        inner: u32,
+    }
+
+    #[derive(Debug, Inspect)]
+    pub enum Data {
+        Named { x: u32, y: u32, z: NonCopy },
+        Tuple(f32, f32),
+        Unit,
+    }
+
+    let data = Data::Named {
+        x: 0,
+        y: 1,
+        z: NonCopy { inner: 10 },
+    };
+
+    assert_eq!(
+        data.properties(),
+        vec![
+            PropertyInfo {
+                owner_type_id: TypeId::of::<Data>(),
+                name: "x",
+                display_name: "X",
+                group: "Data",
+                value: match data {
+                    Data::Named { ref x, .. } => x,
+                    _ => unreachable!(),
+                },
+            },
+            PropertyInfo {
+                owner_type_id: TypeId::of::<Data>(),
+                name: "y",
+                display_name: "Y",
+                group: "Data",
+                value: match data {
+                    Data::Named { ref y, .. } => y,
+                    _ => unreachable!(),
+                },
+            },
+            PropertyInfo {
+                owner_type_id: TypeId::of::<Data>(),
+                name: "z",
+                display_name: "Z",
+                group: "Data",
+                value: match data {
+                    Data::Named { ref z, .. } => z,
+                    _ => unreachable!(),
+                },
+            },
+        ]
+    );
+
+    let data = Data::Tuple(10.0, 20.0);
+
+    assert_eq!(
+        data.properties(),
+        vec![
+            PropertyInfo {
+                owner_type_id: TypeId::of::<Data>(),
+                name: "0",
+                display_name: "0",
+                group: "Data",
+                value: match data {
+                    Data::Tuple(ref f0, ref _f1) => f0,
+                    _ => unreachable!(),
+                },
+            },
+            PropertyInfo {
+                owner_type_id: TypeId::of::<Data>(),
+                name: "1",
+                display_name: "1",
+                group: "Data",
+                value: match data {
+                    Data::Tuple(ref _f0, ref f1) => f1,
+                    _ => unreachable!(),
+                },
+            },
+        ]
+    );
+
+    // unit variants don't have fields
+    let data = Data::Unit;
+    assert_eq!(data.properties(), vec![]);
 }

--- a/src/scene/camera.rs
+++ b/src/scene/camera.rs
@@ -133,7 +133,7 @@ pub struct Camera {
     sky_box: Option<Box<SkyBox>>,
     environment: Option<Texture>,
     #[visit(optional)] // Backward compatibility.
-    #[inspect(expand, include_self)]
+    #[inspect(expand_subtree)]
     exposure: Exposure,
     #[visit(optional)] // Backward compatibility.
     color_grading_lut: Option<ColorGradingLut>,


### PR DESCRIPTION
Closes #189.

## Features

- [x] `#[inspect(expand_subtree)]`: This is `expand` + `include_self` in #189.

<details><summary>example</summary>

```rust
#[derive(Inspect)]
pub struct X {
    #[inspect(expand_subtree)]
    y: Y,
}

#[derive(Inspect)]
pub struct Y {
    a: u32,
}

// expands to

impl Inspect for X {
    fn properties(&self) -> Vec<PropertyInfo<'_>> {
        let mut props = Vec::new();
        props.push(PropertyInfo {
            owner_type_id: std::any::TypeId::of::<Self>(),
            name: "y",
            display_name: "Y",
            group: "X",
            value: (&self.y),
        });
        props.extend((&self.y).properties());
        props
    }
}

impl Inspect for Y {
    fn properties(&self) -> Vec<PropertyInfo<'_>> {
        let mut props = Vec::new();
        props.push(PropertyInfo {
            owner_type_id: std::any::TypeId::of::<Self>(),
            name: "a",
            display_name: "A",
            group: "Y",
            value: (&self.a),
        });
        props
    }
}
```
</details>


- [x] enums
  - [x] `Unit` variant (do nothing)
  - [x] `Tuple(Ty, Ty, ..)` variant
  - [x] `Structural { name: Ty }` variant

<details><summary>enum example</summary>

```rust
#[derive(Inspect)]
pub struct NonCopy {
    inner: u32,
}

#[derive(Inspect)]
pub enum Data {
    Named { x: u32, y: u32, z: NonCopy },
    Tuple(f32, f32),
    Unit,
}

// expands to

impl Inspect for NonCopy {
    fn properties(&self) -> Vec<PropertyInfo<'_>> {
        let mut props = Vec::new();
        props.push(PropertyInfo {
            owner_type_id: std::any::TypeId::of::<Self>(),
            name: "inner",
            display_name: "Inner",
            group: "NonCopy",
            value: (&self.inner),
        });
        props
    }
}

#[automatically_derived]
impl Inspect for Data {
    fn properties(&self) -> Vec<PropertyInfo<'_>> {
        match self {
            Self::Named { x, y, z } => {
                let mut props = Vec::new();
                props.push(PropertyInfo {
                    owner_type_id: std::any::TypeId::of::<Self>(),
                    name: "x",
                    display_name: "X",
                    group: "Data",
                    value: x,
                });
                props.push(PropertyInfo {
                    owner_type_id: std::any::TypeId::of::<Self>(),
                    name: "y",
                    display_name: "Y",
                    group: "Data",
                    value: y,
                });
                props.push(PropertyInfo {
                    owner_type_id: std::any::TypeId::of::<Self>(),
                    name: "z",
                    display_name: "Z",
                    group: "Data",
                    value: z,
                });
                props
            }
            Self::Tuple(f0, f1) => {
                let mut props = Vec::new();
                props.push(PropertyInfo {
                    owner_type_id: std::any::TypeId::of::<Self>(),
                    name: "0",
                    display_name: "0",
                    group: "Data",
                    value: f0,
                });
                props.push(PropertyInfo {
                    owner_type_id: std::any::TypeId::of::<Self>(),
                    name: "1",
                    display_name: "1",
                    group: "Data",
                    value: f1,
                });
                props
            }
            Self::Unit => {
                let mut props = Vec::new();
                props
            }
        }
    }
}
```
</details>

- [x] struct
  - [x] `Unit` variant (do nothing)
  - [x] `Tuple(Ty, Ty, ..)` variant

## Comments

- I failed to keep it simple.. :(
- I named it `expand_subtree`, but it's not so much a tree since the inspection is non-recursive.
- I can update `#[derive(Inspect)]` when `Inspect` API changes :)
