### PR TITLE
`#[derive(Inspect)]`: generate property key constants

### DIFF
--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -5,7 +5,7 @@ mod utils;
 
 use darling::{ast, FromDeriveInput};
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote};
+use quote::{quote};
 use syn::*;
 
 pub fn impl_inspect(ast: DeriveInput) -> TokenStream2 {
@@ -17,60 +17,50 @@ pub fn impl_inspect(ast: DeriveInput) -> TokenStream2 {
 }
 
 fn impl_inspect_struct(ty_args: &args::TypeArgs, field_args: &args::Fields) -> TokenStream2 {
-    let body = utils::gen_inspect_fn_body(ty_args, utils::FieldPrefix::Self_, field_args);
-    utils::create_impl(ty_args, field_args.iter(), body)
+    let field_prefix = utils::FieldPrefix::of_struct(field_args.style);
+    let body = utils::gen_inspect_fn_body(ty_args, field_prefix, field_args);
+    utils::create_inspect_impl(ty_args, field_args.iter(), body)
 }
 
 fn impl_inspect_enum(ty_args: &args::TypeArgs, variant_args: &[args::VariantArgs]) -> TokenStream2 {
-    let variant_matches =
-        variant_args.iter().map(|variant| {
-            let variant_ident = &variant.ident;
+    let variant_matches = variant_args.iter().map(|variant| {
+        let variant_ident = &variant.ident;
 
-            let field_prefix = if variant.fields.style == ast::Style::Struct {
-                utils::FieldPrefix::None
-            } else {
-                utils::FieldPrefix::F
-            };
+        let field_prefix = utils::FieldPrefix::of_enum_variant(variant.fields.style);
 
-            let field_idents = variant.fields.fields.iter().enumerate().map(|(i, field)| {
-                match variant.fields.style {
-                    ast::Style::Struct => field.ident.clone().unwrap(),
-                    ast::Style::Tuple => {
-                        let i = Index::from(i);
-                        format_ident!("f{}", i)
-                    }
-                    ast::Style::Unit => {
-                        format_ident!("<unreachable>")
-                    }
-                }
-            });
+        let field_match_idents = variant
+            .fields
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| field_prefix.field_match_ident(i, field, variant.fields.style));
 
-            let variant_match = match variant.fields.style {
-                ast::Style::Struct => {
-                    quote! {
-                        Self::#variant_ident { #(#field_idents),* }
-                    }
-                }
-                ast::Style::Tuple => {
-                    quote! {
-                        Self::#variant_ident(#(#field_idents),*)
-                    }
-                }
-                ast::Style::Unit => {
-                    quote! {
-                        Self::#variant_ident
-                    }
-                }
-            };
-
-            let fields_inspect = utils::gen_inspect_fn_body(ty_args, field_prefix, &variant.fields);
-
-            quote! {
-                #variant_match => {
-                    #fields_inspect
+        let variant_match = match variant.fields.style {
+            ast::Style::Struct => {
+                quote! {
+                    Self::#variant_ident { #(#field_match_idents),* }
                 }
             }
-        });
+            ast::Style::Tuple => {
+                quote! {
+                    Self::#variant_ident(#(#field_match_idents),*)
+                }
+            }
+            ast::Style::Unit => {
+                quote! {
+                    Self::#variant_ident
+                }
+            }
+        };
+
+        let fields_inspects = utils::gen_inspect_fn_body(ty_args, field_prefix, &variant.fields);
+
+        quote! {
+            #variant_match => {
+                #fields_inspects
+            }
+        }
+    });
 
     let body = quote! {
         match self {
@@ -79,5 +69,5 @@ fn impl_inspect_enum(ty_args: &args::TypeArgs, variant_args: &[args::VariantArgs
     };
 
     let field_args = variant_args.iter().flat_map(|v| v.fields.iter());
-    utils::create_impl(ty_args, field_args, body)
+    utils::create_inspect_impl(ty_args, field_args, body)
 }

--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -5,7 +5,7 @@ mod utils;
 
 use darling::{ast, FromDeriveInput};
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{quote};
+use quote::quote;
 use syn::*;
 
 pub fn impl_inspect(ast: DeriveInput) -> TokenStream2 {

--- a/rg3d-core-derive/src/inspect.rs
+++ b/rg3d-core-derive/src/inspect.rs
@@ -16,10 +16,7 @@ pub fn impl_inspect(ast: DeriveInput) -> TokenStream2 {
     }
 }
 
-fn impl_inspect_struct(
-    ty_args: &args::TypeArgs,
-    field_args: &ast::Fields<args::FieldArgs>,
-) -> TokenStream2 {
+fn impl_inspect_struct(ty_args: &args::TypeArgs, field_args: &args::Fields) -> TokenStream2 {
     let body = utils::gen_inspect_fn_body(ty_args, utils::FieldPrefix::Self_, field_args);
     utils::create_impl(ty_args, field_args.iter(), body)
 }

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -1,6 +1,6 @@
-//! Derive input types by `darling`.
+//! Derive input types defined with `darling`.
 //!
-//! They parse `#[attributes(..)]` in declartive style, different from `syn`.
+//! They parse `#[attributes(..)]` syntax in a declartive style.
 
 use darling::*;
 use syn::*;
@@ -19,7 +19,7 @@ pub struct TypeArgs {
 /// Parsed from struct's or enum variant's field
 ///
 /// NOTE: `#[derive(Inspect)]` is non-recursive by default.
-#[derive(FromField, Clone)]
+#[derive(FromField, Clone, PartialEq)]
 #[darling(attributes(inspect))]
 pub struct FieldArgs {
     pub ident: Option<Ident>,
@@ -64,7 +64,7 @@ pub struct FieldArgs {
 
     /// `#[inspect(read_only)]`
     ///
-    /// The field is not meant to be edited.    
+    /// The field is not meant to be edited.
     #[darling(default)]
     pub read_only: bool,
 }

--- a/rg3d-core-derive/src/inspect/args.rs
+++ b/rg3d-core-derive/src/inspect/args.rs
@@ -5,6 +5,9 @@
 use darling::*;
 use syn::*;
 
+// pub type Data = ast::Data<VariantArgs, FieldArgs>;
+pub type Fields = ast::Fields<FieldArgs>;
+
 #[derive(FromDeriveInput)]
 #[darling(attributes(inspect), supports(struct_any, enum_any))]
 pub struct TypeArgs {

--- a/rg3d-core-derive/src/inspect/utils.rs
+++ b/rg3d-core-derive/src/inspect/utils.rs
@@ -102,6 +102,7 @@ fn prop_keys_impl(ty_args: &args::TypeArgs) -> TokenStream2 {
 
     let prop_keys = prop_keys::quote_prop_keys(ty_args);
     quote! {
+        /// Property key constants
         impl #impl_generics #ty_ident #ty_generics #where_clause {
             #prop_keys
         }

--- a/rg3d-core-derive/src/inspect/utils/prop_keys.rs
+++ b/rg3d-core-derive/src/inspect/utils/prop_keys.rs
@@ -50,6 +50,7 @@ pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
 
     quote! {
         #(
+            #[allow(missing_docs)]
             pub const #prop_idents: &'static str = #prop_names;
         )*
     }

--- a/rg3d-core-derive/src/inspect/utils/prop_keys.rs
+++ b/rg3d-core-derive/src/inspect/utils/prop_keys.rs
@@ -1,0 +1,86 @@
+//! Generate property keys (constant fields)
+
+use convert_case::{Case, Casing};
+use darling::ast;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::*;
+
+use crate::inspect::{args, utils};
+
+/// Returns a list of `pub const [VARIANT_]FIELD: &'static str = "key_value"`;
+pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
+    let mut prop_idents = Vec::new();
+    let mut prop_names = Vec::new();
+
+    match &ty_args.data {
+        ast::Data::Struct(field_args) => {
+            for (nth, field) in field_args.fields.iter().enumerate() {
+                // don't expose uninspectable fields' properties
+                if field.expand || field.skip {
+                    continue;
+                }
+
+                let prop_ident = self::struct_field_prop(ty_args, nth, field);
+                let prop_name = utils::prop_name(nth, field);
+
+                prop_idents.push(prop_ident);
+                prop_names.push(prop_name);
+            }
+        }
+        ast::Data::Enum(variants) => {
+            for v in variants {
+                for (nth, field) in v.fields.iter().enumerate() {
+                    // don't expose uninspectable fields' properties
+                    if field.expand || field.skip {
+                        continue;
+                    }
+
+                    // REMARK: We can't refer to expanded fields
+
+                    let prop_ident = self::enum_field_prop(v, nth, field);
+                    let prop_name = utils::prop_name(nth, field);
+
+                    prop_idents.push(prop_ident);
+                    prop_names.push(prop_name);
+                }
+            }
+        }
+    }
+
+    quote! {
+        #(
+            pub const #prop_idents: &'static str = #prop_names;
+        )*
+    }
+}
+
+fn struct_field_prop(ty_args: &args::TypeArgs, nth: usize, field: &args::FieldArgs) -> Ident {
+    let fields = match &ty_args.data {
+        ast::Data::Struct(xs) => xs,
+        _ => unreachable!(),
+    };
+    let field_ident = self::field_ident(&fields, nth, field);
+
+    let ident = format!("{}", field_ident).to_case(Case::UpperSnake);
+    syn::parse_str(&ident).unwrap()
+}
+
+fn enum_field_prop(variant_args: &args::VariantArgs, nth: usize, field: &args::FieldArgs) -> Ident {
+    let variant_ident = &variant_args.ident;
+    let field_ident = self::field_ident(&variant_args.fields, nth, field);
+
+    let ident = format!("{}_{}", variant_ident, field_ident).to_case(Case::UpperSnake);
+    syn::parse_str(&ident).unwrap()
+}
+
+fn field_ident(fields: &args::Fields, nth: usize, field: &args::FieldArgs) -> String {
+    match fields.style {
+        ast::Style::Struct => field.ident.as_ref().unwrap().to_string(),
+        ast::Style::Tuple => {
+            // this is actually `F_0` in UPPER_SNAKE_CASE
+            format!("F{}", nth)
+        }
+        ast::Style::Unit => unreachable!(),
+    }
+}

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -46,14 +46,16 @@ fn inspect_attributes() {
 
     #[derive(Debug, Default, Inspect)]
     pub struct Data {
+        // NOTE: Even though this field is skipped, the next field is given index `1` for simplicity
         #[inspect(skip)]
         _skipped: u32,
         #[inspect(group = "Pos", name = "the_x", display_name = "Super X")]
         x: f32,
-        // Expand properties are added to the end of the list
+        // Expand properties are added to the end of the list.
+        // NOTE: Even though this field inspection is postponed, this field is given index `2`
         #[inspect(expand)]
         aar_gee: AarGee,
-        #[inspect(group = "Pos")]
+        #[inspect(group = "Pos", read_only)]
         y: f32,
     }
 
@@ -74,7 +76,7 @@ fn inspect_attributes() {
             display_name: "Y",
             group: "Pos",
             value: &data.y,
-            read_only: false,
+            read_only: true,
         },
     ];
 
@@ -111,7 +113,7 @@ fn inspect_struct() {
                 display_name: "0",
                 group: "Tuple",
                 value: &x.0,
-                read_only: false
+                read_only: false,
             },
             PropertyInfo {
                 owner_type_id: TypeId::of::<Tuple>(),
@@ -119,7 +121,7 @@ fn inspect_struct() {
                 display_name: "1",
                 group: "Tuple",
                 value: &x.1,
-                read_only: false
+                read_only: false,
             },
         ]
     );

--- a/rg3d-core-derive/tests/it/inspect.rs
+++ b/rg3d-core-derive/tests/it/inspect.rs
@@ -226,3 +226,45 @@ fn inspect_enum() {
     let data = Data::Unit;
     assert_eq!(data.properties(), vec![]);
 }
+
+#[test]
+fn inspect_prop_key_constants() {
+    #[derive(Debug, Inspect)]
+    pub struct X;
+
+    #[derive(Inspect)]
+    pub struct SStruct {
+        field: usize,
+        #[inspect(skip)]
+        hidden: usize,
+        #[inspect(expand)]
+        expand: X,
+        #[inspect(expand_subtree)]
+        expand_subtree: X,
+    }
+
+    // NOTE: property names are in snake_case (not Title Case)
+    assert_eq!(SStruct::FIELD, "field");
+    // property keys for uninspectable fields are NOT emitted
+    // assert_eq!(SStruct::HIDDEN, "hidden");
+    // assert_eq!(SStruct::EXPAND, "expand");
+    assert_eq!(SStruct::EXPAND_SUBTREE, "expand_subtree");
+
+    #[derive(Inspect)]
+    pub struct STuple(usize);
+    assert_eq!(STuple::F_0, "0");
+
+    #[derive(Inspect)]
+    #[allow(unused)]
+    pub enum E {
+        Tuple(usize),
+        Struct { field: usize },
+        Unit,
+    }
+
+    assert_eq!(E::TUPLE_F_0, "0");
+    assert_eq!(E::STRUCT_FIELD, "field");
+
+    // variant itself it not a property
+    // assert_eq!(E::UNIT, "unit");
+}


### PR DESCRIPTION
Hi 👋  mr! I'm recently impressed by your realtime attack.. can't estimate your love!

Closes #193. The constants _should_ work as expected, but I didn't test (sorry).

![prop-keys](https://user-images.githubusercontent.com/47905926/135760233-d2ca88cd-a452-4e3d-b120-34c35dbce4e5.png)

- The constants pullute docs 🤔  But I [didn't find any][D] `#[doc(shrink_by_default)]` attribute.
- Property key constants for private fields are exposed (if it matters, another PR can come).
- Note that there's no key constants for expanded (flatten) field properties (since we can't track the expanded type's fields).

[D]: https://doc.rust-lang.org/rustdoc/the-doc-attribute.html

---

By the way, [this line][L] of `examples/inspector.rs` needs one more field. You might know, but just in case :)

[L]: https://github.com/rg3dengine/rg3d/blob/master/examples/inspector.rs#L141