### PR TITLE
Reexport subcrates as modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,26 @@ pub use walkdir;
 pub use winit::*;
 
 /// Core data structures and algorithms used throughout rg3d. Re-exported from the [rg3d_core](https://docs.rs/rg3d_core/*/rg3d_core/) crate.
-pub mod core { pub use ::rg3d_core::*; }
+pub mod core {
+    pub use ::rg3d_core::*;
+}
 /// Physics for 2D scenes using the Rapier physics engine. Re-exported from the [rg3d_physics2d](https://docs.rs/rg3d_physics2d/*/rg3d_physics2d/) crate.
-pub mod physics2d { pub use rg3d_physics2d::*; }
+pub mod physics2d {
+    pub use rg3d_physics2d::*;
+}
 /// Physics for 3D scenes using the Rapier physics engine. Re-exported from the [rg3d_physics3d](https://docs.rs/rg3d_physics3d/*/rg3d_physics3d/) crate.
-pub mod physics3d { pub use rg3d_physics3d::*; }
+pub mod physics3d {
+    pub use rg3d_physics3d::*;
+}
 /// Resource management. Re-exported from the [rg3d_resource](https://docs.rs/rg3d_resource/*/rg3d_resource/) crate.
-pub mod asset { pub use rg3d_resource::*; }
+pub mod asset {
+    pub use rg3d_resource::*;
+}
 /// Sound library for games and interactive applications. Re-exported from the [rg3d_sound](https://docs.rs/rg3d_sound/*/rg3d_sound/) crate.
-pub mod sound { pub use rg3d_sound::*; }
+pub mod sound {
+    pub use rg3d_sound::*;
+}
 /// Extendable, retained mode, graphics API agnostic UI library. Re-exported from the [rg3d_ui](https://docs.rs/rg3d_ui/*/rg3d_ui/) crate.
-pub mod gui { pub use rg3d_ui::*; }
+pub mod gui {
+    pub use rg3d_ui::*;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,9 @@ pub use winit::*;
 
 /// Core data structures and algorithms used throughout rg3d. Re-exported from the [rg3d_core](https://docs.rs/rg3d_core/*/rg3d_core/) crate.
 pub mod core { pub use ::rg3d_core::*; }
-/// Physics for 2D scenes using the Rapier physics engine. Re-exported from the rg3d_physics2d crate.
+/// Physics for 2D scenes using the Rapier physics engine. Re-exported from the [rg3d_physics2d](https://docs.rs/rg3d_physics2d/*/rg3d_physics2d/) crate.
 pub mod physics2d { pub use rg3d_physics2d::*; }
-/// Physics for 3D scenes using the Rapier physics engine. Re-exported from the rg3d_physics3d crate.
+/// Physics for 3D scenes using the Rapier physics engine. Re-exported from the [rg3d_physics3d](https://docs.rs/rg3d_physics3d/*/rg3d_physics3d/) crate.
 pub mod physics3d { pub use rg3d_physics3d::*; }
 /// Resource management. Re-exported from the [rg3d_resource](https://docs.rs/rg3d_resource/*/rg3d_resource/) crate.
 pub mod asset { pub use rg3d_resource::*; }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,15 @@ pub use walkdir;
 #[cfg(target_arch = "wasm32")]
 pub use winit::*;
 
-pub use rg3d_core as core;
-pub use rg3d_physics2d as physics2d;
-pub use rg3d_physics3d as physics3d;
-pub use rg3d_resource as asset;
-pub use rg3d_sound as sound;
-pub use rg3d_ui as gui;
+/// Core data structures and algorithms used throughout rg3d. Re-exported from the [rg3d_core](https://docs.rs/rg3d_core/*/rg3d_core/) crate.
+pub mod core { pub use ::rg3d_core::*; }
+/// Physics for 2D scenes using the Rapier physics engine. Re-exported from the rg3d_physics2d crate.
+pub mod physics2d { pub use rg3d_physics2d::*; }
+/// Physics for 3D scenes using the Rapier physics engine. Re-exported from the rg3d_physics3d crate.
+pub mod physics3d { pub use rg3d_physics3d::*; }
+/// Resource management. Re-exported from the [rg3d_resource](https://docs.rs/rg3d_resource/*/rg3d_resource/) crate.
+pub mod asset { pub use rg3d_resource::*; }
+/// Sound library for games and interactive applications. Re-exported from the [rg3d_sound](https://docs.rs/rg3d_sound/*/rg3d_sound/) crate.
+pub mod sound { pub use rg3d_sound::*; }
+/// Extendable, retained mode, graphics API agnostic UI library. Re-exported from the [rg3d_ui](https://docs.rs/rg3d_ui/*/rg3d_ui/) crate.
+pub mod gui { pub use rg3d_ui::*; }


### PR DESCRIPTION
This makes them searchable from the main rg3d docs page

Downside is people are less likely to see the doc comment on the subcrates - for example rg3d_sound has a nice example there. Might be worth at least copy pasting it into the module doc comment, unless there's a better solution.

Also noticed rg3d_physics2d and 3d are not on crates.io yet but the links i added should work after they're published.