### PR TITLE
Pool u32

### DIFF
--- a/rg3d-core/src/pool.rs
+++ b/rg3d-core/src/pool.rs
@@ -1013,6 +1013,11 @@ impl<T> Pool<T> {
         self.iter().count()
     }
 
+    pub fn count(&self) -> u32 {
+        let free = u32::try_from(self.free_stack.len()).expect("free stack length overflowed u32");
+        self.records_len() - free
+    }
+
     #[inline]
     pub fn replace(&mut self, handle: Handle<T>, payload: T) -> Option<T> {
         if let Some(record) = self.records.get_mut(handle.index as usize) {

--- a/rg3d-core/src/pool.rs
+++ b/rg3d-core/src/pool.rs
@@ -935,7 +935,9 @@ impl<T> Pool<T> {
     /// Returns the value back into the pool using the given ticket. See [`take_reserve`] for more
     /// information.
     pub fn put_back(&mut self, ticket: Ticket<T>, value: T) -> Handle<T> {
-        let record = self.records_get_mut(ticket.index).expect("Ticket index was invalid");
+        let record = self
+            .records_get_mut(ticket.index)
+            .expect("Ticket index was invalid");
         let old = record.payload.replace(value);
         assert!(old.is_none());
         Handle::new(ticket.index, record.generation)
@@ -1172,7 +1174,8 @@ impl<T> FromIterator<T> for Pool<T> {
         let iter = iter.into_iter();
         let (lower_bound, upper_bound) = iter.size_hint();
         let lower_bound = u32::try_from(lower_bound).expect("lower_bound overflowed u32");
-        let upper_bound = upper_bound.map(|b| u32::try_from(b).expect("upper_bound overflowed u32"));
+        let upper_bound =
+            upper_bound.map(|b| u32::try_from(b).expect("upper_bound overflowed u32"));
         let mut pool = Self::with_capacity(upper_bound.unwrap_or(lower_bound));
         for v in iter.into_iter() {
             let _ = pool.spawn(v);

--- a/rg3d-core/src/pool.rs
+++ b/rg3d-core/src/pool.rs
@@ -883,6 +883,8 @@ impl<T> Pool<T> {
     /// # Panics
     ///
     /// Panics if the given handle is invalid.
+    ///
+    /// [`put_back`]: Pool::put_back
     #[inline]
     pub fn take_reserve(&mut self, handle: Handle<T>) -> (Ticket<T>, T) {
         if let Some(record) = self.records_get_mut(handle.index) {
@@ -911,6 +913,8 @@ impl<T> Pool<T> {
     }
 
     /// Does the same as [`take_reserve`] but returns an option, instead of panicking.
+    ///
+    /// [`take_reserve`]: Pool::take_reserve
     #[inline]
     pub fn try_take_reserve(&mut self, handle: Handle<T>) -> Option<(Ticket<T>, T)> {
         if let Some(record) = self.records_get_mut(handle.index) {
@@ -934,6 +938,8 @@ impl<T> Pool<T> {
 
     /// Returns the value back into the pool using the given ticket. See [`take_reserve`] for more
     /// information.
+    ///
+    /// [`take_reserve`]: Pool::take_reserve
     pub fn put_back(&mut self, ticket: Ticket<T>, value: T) -> Handle<T> {
         let record = self
             .records_get_mut(ticket.index)
@@ -964,7 +970,6 @@ impl<T> Pool<T> {
     /// Use this method cautiously if objects in pool have cross "references" (handles)
     /// to each other. This method will make all produced handles invalid and any further
     /// calls for [`borrow`](Self::borrow) or [`borrow_mut`](Self::borrow_mut) will raise panic.
-    ///
     #[inline]
     pub fn clear(&mut self) {
         self.records.clear();

--- a/rg3d-sound/src/context.rs
+++ b/rg3d-sound/src/context.rs
@@ -253,13 +253,10 @@ impl State {
         let last_time = rg3d_core::instant::Instant::now();
 
         if !self.paused {
-            for i in 0..self.sources.get_capacity() {
-                if let Some(source) = self.sources.at(i) {
-                    if source.is_play_once() && source.status() == Status::Stopped {
-                        self.sources.free(self.sources.handle_from_index(i));
-                    }
-                }
-            }
+            self.sources.retain(|source| {
+                let done = source.is_play_once() && source.status() == Status::Stopped;
+                !done
+            });
 
             for source in self
                 .sources

--- a/src/scene/graph.rs
+++ b/src/scene/graph.rs
@@ -859,7 +859,7 @@ impl Graph {
     ///     }
     /// }
     /// ```
-    pub fn capacity(&self) -> usize {
+    pub fn capacity(&self) -> u32 {
         self.pool.get_capacity()
     }
 
@@ -880,7 +880,7 @@ impl Graph {
     ///     }
     /// }
     /// ```
-    pub fn handle_from_index(&self, index: usize) -> Handle<Node> {
+    pub fn handle_from_index(&self, index: u32) -> Handle<Node> {
         self.pool.handle_from_index(index)
     }
 

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -88,7 +88,7 @@ impl NavMeshContainer {
     }
 
     /// Creates a handle to navmesh from its index.
-    pub fn handle_from_index(&self, i: usize) -> Handle<Navmesh> {
+    pub fn handle_from_index(&self, i: u32) -> Handle<Navmesh> {
         self.pool.handle_from_index(i)
     }
 

--- a/src/scene2d/graph.rs
+++ b/src/scene2d/graph.rs
@@ -131,13 +131,13 @@ impl Graph {
             .set_position(Vector2::default());
     }
 
-    pub fn capacity(&self) -> usize {
+    pub fn capacity(&self) -> u32 {
         self.pool.get_capacity()
     }
 
     /// Makes new handle from given index. Handle will be none if index was either out-of-bounds
     /// or point to a vacant pool entry.
-    pub fn handle_from_index(&self, index: usize) -> Handle<Node> {
+    pub fn handle_from_index(&self, index: u32) -> Handle<Node> {
         self.pool.handle_from_index(index)
     }
 


### PR DESCRIPTION
- Converted usize to u32 where possible, surprisingly didn't really cause breakage in other parts of the code. Editor and Iapetus are also unaffected.
- `records_get_mut` (and friends) was meant to keep the conversions in one place. Unfortunately rust doesn't have partial borrows yet so it keeps the whole pool borrowed and i couldn't use it in all the places i would have liked - e.g. `free` still needs to do the conversion inside the method itself. It doesn't really matter much but little things like these really annoy the perfectionist in me. Technically `Vec`s in pool could be replaced with some crate that uses u32 instead of usize but it's almost certainly not worth bringing the extra dep.
- Now there's fewer `as` conversions but i still don't feel comfortable that Pool will behave in a sane way if somebody decides to spawn more than 2^32 objects.
- Improved some docs. `put_back` doesn't panic unless there's a bug in `Pool` so removed the Panics heading.

Questions remaining (brought up on discord):
- Change the behavior of `alive_count`? `count` is a proposal for an O(1) solution but behaves differently when reserved objects are in the pool.
- Rename `get_capacity` to `max_len` or something similar?