### PR TITLE
Remove unused structs

### DIFF
--- a/rg3d-ui/src/ttf.rs
+++ b/rg3d-ui/src/ttf.rs
@@ -10,18 +10,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-#[derive(Copy, Clone, Debug)]
-struct Point {
-    x: f32,
-    y: f32,
-    flags: u8,
-}
-
-#[derive(Debug)]
-struct Polygon {
-    points: Vec<Point>,
-}
-
 #[derive(Debug)]
 pub struct FontGlyph {
     pub top: f32,


### PR DESCRIPTION
My clippy has been reporting these as unused for a long time but CI only started failing recently, probably something got fixed in the new release.

There are still 2 unused fields in the codebase but i am not sure what to do with them so i left them to you.