### PR TITLE
Replace DefaultHasher with FxHasher

### DIFF
--- a/rg3d-core/src/profiler.rs
+++ b/rg3d-core/src/profiler.rs
@@ -4,9 +4,8 @@
 
 #![allow(dead_code)]
 
-use fxhash::{FxHashMap, FxHashSet};
+use fxhash::{FxHashMap, FxHashSet, FxHasher};
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -102,7 +101,7 @@ impl Default for Profiler {
 }
 
 fn calculate_hash<T: Hash>(t: &T) -> u64 {
-    let mut s = DefaultHasher::new();
+    let mut s = FxHasher::default();
     t.hash(&mut s);
     s.finish()
 }

--- a/rg3d-core/src/sstorage.rs
+++ b/rg3d-core/src/sstorage.rs
@@ -7,9 +7,8 @@ use crate::{
     parking_lot::Mutex,
     visitor::{Visit, VisitResult, Visitor},
 };
-use fxhash::FxHashMap;
+use fxhash::{FxHashMap, FxHasher};
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::{Display, Formatter},
     hash::{Hash, Hasher},
     ops::Deref,
@@ -119,7 +118,7 @@ pub struct ImmutableStringStorage {
 impl ImmutableStringStorage {
     #[inline]
     fn insert<S: AsRef<str>>(&mut self, string: S) -> ImmutableString {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = FxHasher::default();
         string.as_ref().hash(&mut hasher);
         let hash = hasher.finish();
 

--- a/src/renderer/batch.rs
+++ b/src/renderer/batch.rs
@@ -11,9 +11,8 @@ use crate::{
     },
     utils::log::{Log, MessageKind},
 };
-use fxhash::FxHashMap;
+use fxhash::{FxHashMap, FxHasher};
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::{Debug, Formatter},
     hash::Hasher,
     sync::Arc,
@@ -138,7 +137,7 @@ impl BatchStorage {
                                 Ok(_) => {
                                     let material = Arc::new(Mutex::new(material));
 
-                                    let mut hasher = DefaultHasher::new();
+                                    let mut hasher = FxHasher::default();
 
                                     hasher.write_u64(&*material as *const _ as u64);
                                     hasher.write_u64(data_key);

--- a/src/resource/texture.rs
+++ b/src/resource/texture.rs
@@ -29,11 +29,11 @@ use crate::{
     },
 };
 use ddsfile::{Caps2, D3DFormat};
+use fxhash::FxHasher;
 use image::{ColorType, DynamicImage, GenericImageView, ImageError, ImageFormat};
-use std::fmt::{Debug, Formatter};
 use std::{
     borrow::Cow,
-    collections::hash_map::DefaultHasher,
+    fmt::{Debug, Formatter},
     hash::{Hash, Hasher},
     io::Cursor,
     ops::{Deref, DerefMut},
@@ -668,7 +668,7 @@ fn compress_rg8_bc4<T: tbc::color::ColorRedGreen8>(
 }
 
 fn data_hash(data: &[u8]) -> u64 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = FxHasher::default();
     data.hash(&mut hasher);
     hasher.finish()
 }

--- a/src/scene/mesh/buffer.rs
+++ b/src/scene/mesh/buffer.rs
@@ -17,10 +17,13 @@ use crate::{
     },
     utils::value_as_u8_slice,
 };
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::ops::{Deref, DerefMut, Index, IndexMut};
-use std::{marker::PhantomData, mem::MaybeUninit};
+use fxhash::FxHasher;
+use std::{
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut, Index, IndexMut},
+};
 
 /// Data type for a vertex attribute component.
 #[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Ord, Hash, Visit, Debug)]
@@ -148,7 +151,7 @@ pub struct VertexBuffer {
 }
 
 fn calculate_data_hash(data: &[u8]) -> u64 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = FxHasher::default();
     data.hash(&mut hasher);
     hasher.finish()
 }
@@ -910,7 +913,7 @@ pub struct GeometryBuffer {
 }
 
 fn calculate_geometry_buffer_hash(triangles: &[TriangleDefinition]) -> u64 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = FxHasher::default();
     triangles.hash(&mut hasher);
     hasher.finish()
 }

--- a/src/scene/mesh/surface.rs
+++ b/src/scene/mesh/surface.rs
@@ -29,7 +29,8 @@ use crate::{
     },
     utils::raw_mesh::{RawMesh, RawMeshBuilder},
 };
-use std::{collections::hash_map::DefaultHasher, hash::Hasher, sync::Arc};
+use fxhash::FxHasher;
+use std::{hash::Hasher, sync::Arc};
 
 /// Data source of a surface. Each surface can share same data source, this is used
 /// in instancing technique to render multiple instances of same model at different
@@ -945,7 +946,7 @@ impl Surface {
 
     /// Calculates batch id.
     pub fn batch_id(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = FxHasher::default();
         hasher.write_u64(self.material_id());
         hasher.write_u64(&**self.data.as_ref().unwrap() as *const _ as u64);
         hasher.finish()


### PR DESCRIPTION
I didn't do a thorough check but it looks like none of these hashes survive after engine exit so changing them should be ok. Besides, DefaultHasher doesn't guarantee stable hashes either.