### PR TITLE
Improve CI (matrix, --workspace)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 on: [push, pull_request]
 env:
   CARGO_TERM_COLOR: always
+  # Deny warns here as a catch-all and because some commands (e.g. cargo build) don't accept `--deny warnings`
+  # but also deny them on all individual cargo invocations where available because:
+  # 1) Some commands might not support rustflags (e.g. clippy didn't at first, cargo doc uses a different var, ...)
+  # 2) People might copy paste the commands into CI where this flag is missing without noticing.
+  RUSTFLAGS: --deny warnings
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           toolchain: nightly # Check on nightly because it sometimes has more lints.
           profile: minimal
+          components: clippy
           override: true
       - name: Update
         run: sudo apt update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,56 +4,54 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  windows:
-    name: Windows CI
-    runs-on: windows-latest
-
+  tests:
+    name: Tests CI
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [stable, nightly]
+        # For reference: https://github.com/actions/virtual-environments#available-environments
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - run: rustup update
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+      - name: Install linux deps
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update # Run update first or install might start failing eventually.
+          sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev pkg-config xorg-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
       - run: rustc --version && cargo --version
       - name: Build
-        run: cargo check --verbose
+        # Use build instead of check since it needs to be built for tests anyway
+        run: cargo build --verbose --workspace --all-targets --all-features
       - name: Test
-        run: cargo test --verbose
-
-  macosx:
-    name: MacOSX CI
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - run: rustup update
-      - run: rustc --version && cargo --version
-      - name: Build
-        run: cargo check --verbose
-      - name: Test
-        run: cargo test --verbose
-
-  linux:
-    name: Linux CI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Update
-        run: sudo apt update
-      - name: Install Dependencies
-        run: sudo apt-get install libasound2-dev libudev-dev pkg-config xorg-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
-      - run: rustup update
-      - run: rustc --version && cargo --version
-      - name: Build
-        run: cargo check --verbose
-      - name: Test
-        run: cargo test --verbose
+        # Currently --all-targets *disables* running doc-tests
+        # and none of the other targets such as examples *currently* have tests
+        # so we don't use it. It should be added later when the issue is fixed:
+        # https://github.com/rust-lang/cargo/issues/6669
+        run: cargo test --verbose --workspace --all-features
 
   wasm:
     name: Wasm CI
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
       - name: Install Dependencies
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - run: rustup update
       - run: rustc --version && cargo --version && wasm-pack --version
       - name: Build
         run: |
@@ -78,15 +76,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: rustup update
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly # Check on nightly because it sometimes has more lints.
+          profile: minimal
+          override: true
       - name: Update
         run: sudo apt update
       - name: Install Dependencies
-        run: sudo apt-get install libasound2-dev libudev-dev pkg-config xorg-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+        run: |
+          sudo apt-get update # Run update first or install might start failing eventually
+          sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev pkg-config xorg-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
       - run: cargo clippy --version
         # Using --all-targets to also check tests and examples.
         # Note that technically --all-features doesn't check all code when something is *disabled* by a feature.
-      - run: cargo clippy --all-targets --all-features -- --deny warnings
+      - run: cargo clippy --workspace --all-targets --all-features -- --deny warnings
 
   docs:
     name: Documentation CI
@@ -95,24 +99,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly # docs.rs uses nightly: https://docs.rs/about/builds
+          profile: minimal
           override: true
       - run: rustc --version && cargo --version
       - name: Build Docs
         run: cargo doc --all-features
         env:
           RUSTDOCFLAGS: --deny warnings
-
-  # MacOS 11 CI is currently in beta. Uncomment the below lines when it's out of beta.
-  # For reference: https://github.com/actions/virtual-environments#available-environments
-  # macos11:
-  #   name: MacOS Big Sur (M1) CI
-  #   runs-on: macos-11
-
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Build
-  #     run: cargo build --verbose
-  #   - name: Test
-  #     run: cargo test --verbose


### PR DESCRIPTION
Surprise! We haven't been running most tests or lints because nobody added --workspace :/

Also fixes rg3dengine#228

Removing comment about macOS 11 since it's gonna be the default for macos-latest soon: actions/virtual-environments#4060

So now this should find a bunch of new issues, might wanna merge this only after fixing those.