### PR TITLE
Futures 0.3.18 has been Yanked

### DIFF
--- a/rg3d-core/Cargo.toml
+++ b/rg3d-core/Cargo.toml
@@ -25,7 +25,7 @@ memoffset = "0.6.5"
 lazy_static = "1.4.0"
 nalgebra = "0.29.0"
 arrayvec = "0.7.2"
-futures = {version = "0.3.18", features = ["thread-pool"] }
+futures = {version = "0.3.17", features = ["thread-pool"] }
 uuid = { version = "0.8.2", features = ["v4","wasm-bindgen"] }
 instant = {version = "0.1.12", features = ["wasm-bindgen"] }
 num-traits = "0.2.14"


### PR DESCRIPTION
See: https://github.com/rust-lang/futures-rs/issues/2529

As a result `futures = "0.3.18"` is no longer available on crates.io.
```
$ cargo metadata
warning: please specify `--format-version` flag explicitly to avoid compatibility problems
    Updating git repository `https://github.com/rg3dengine/rg3d`
    Updating crates.io index
error: failed to select a version for the requirement `futures = "^0.3.18"`
candidate versions found which didn't match: 0.3.17, 0.3.16, 0.3.15, ...
location searched: crates.io index
required by package `rg3d-core v0.18.0 (https://github.com/rg3dengine/rg3d#ec581b75)`
    ... which satisfies git dependency `rg3d-core` of package `rg3d v0.24.0 (https://github.com/rg3dengine/rg3d#ec581b75)`
    ... which satisfies git dependency `rg3d` of package `game v0.1.0 (/home/thomas/Repositories/game)`
```